### PR TITLE
rebrand: Claude/Anthropic → Verboo em tool prompts, mensagens de erro e CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@
 #
 # ── Provider variables ───────────────────────────────────────────────
 #
-#   Option 1 — Anthropic:
+#   Option 1 — Verboo:
 #     ANTHROPIC_API_KEY=sk-ant-your-key-here
 #     ANTHROPIC_MODEL=claude-sonnet-4-5              (optional)
 #     ANTHROPIC_BASE_URL=https://api.anthropic.com   (optional)
@@ -172,7 +172,7 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 
 # Fallback context window size (tokens) when the model is not found in the
 # built-in table (default: 128000). Increase this for models with larger
-# context windows (e.g. 200000 for Claude-sized contexts).
+# context windows (e.g. 200000 for Verboo-sized contexts).
 # CLAUDE_CODE_OPENAI_FALLBACK_CONTEXT_WINDOW=128000
 
 # Per-model context window overrides as a JSON object.
@@ -349,7 +349,7 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # WEB SEARCH (OPTIONAL)
 # =============================================================================
 # Verboo Code includes a web search tool. By default it uses DuckDuckGo (free)
-# or the provider's native search (Anthropic firstParty / vertex).
+# or the provider's native search (Verboo firstParty / vertex).
 #
 # Set one API key below to enable a provider. That's it.
 
@@ -394,7 +394,7 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 #   "mojeek"    — mojeek only
 #   "linkup"    — linkup only
 #   "ddg"       — duckduckgo only
-#   "native"    — anthropic native / codex only
+#   "native"    — verboo native / codex only
 #
 # Auto mode priority: firecrawl → tavily → exa → you → jina → bing → mojeek →
 #                     linkup → ddg

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -152,7 +152,7 @@ export async function update() {
         writeToStdout('To update, run:\n')
         writeToStdout(chalk.bold('  brew upgrade verboo-code') + '\n')
       } else {
-        writeToStdout('Claude is up to date!\n')
+        writeToStdout('Verboo Code is up to date!\n')
       }
     } else if (packageManager === 'winget') {
       writeToStdout('Verboo Code is managed by winget.\n')
@@ -165,7 +165,7 @@ export async function update() {
           chalk.bold('  winget upgrade Anthropic.ClaudeCode') + '\n',
         )
       } else {
-        writeToStdout('Claude is up to date!\n')
+        writeToStdout('Verboo Code is up to date!\n')
       }
     } else if (packageManager === 'apk') {
       writeToStdout('Verboo Code is managed by apk.\n')
@@ -176,7 +176,7 @@ export async function update() {
         writeToStdout('To update, run:\n')
         writeToStdout(chalk.bold('  apk upgrade verboo-code') + '\n')
       } else {
-        writeToStdout('Claude is up to date!\n')
+        writeToStdout('Verboo Code is up to date!\n')
       }
     } else {
       // pacman, deb, and rpm don't get specific commands because they each have

--- a/src/commands/chrome/index.ts
+++ b/src/commands/chrome/index.ts
@@ -3,7 +3,7 @@ import type { Command } from '../../commands.js'
 
 const command: Command = {
   name: 'chrome',
-  description: 'Claude in Chrome (Beta) settings',
+  description: 'Verboo in Chrome (Beta) settings',
   availability: ['claude-ai'],
   isEnabled: () => !getIsNonInteractiveSession(),
   type: 'local-jsx',

--- a/src/commands/install.tsx
+++ b/src/commands/install.tsx
@@ -113,7 +113,7 @@ function Install({
 
         // Check specifically for lock failure
         if (result.lockFailed) {
-          throw new Error('Could not install - another process is currently installing Claude. Please try again in a moment.');
+          throw new Error('Could not install - another process is currently installing Verboo Code. Please try again in a moment.');
         }
 
         // If we couldn't get the version, there might be an issue

--- a/src/tasks/RemoteAgentTask/RemoteAgentTask.tsx
+++ b/src/tasks/RemoteAgentTask/RemoteAgentTask.tsx
@@ -146,7 +146,7 @@ export async function checkRemoteAgentEligibility({
 export function formatPreconditionError(error: BackgroundRemoteSessionPrecondition): string {
   switch (error.type) {
     case 'not_logged_in':
-      return 'Please run /login and sign in with your Claude.ai account (not Console).';
+      return 'Please run /login and sign in with your Verboo account (not Console).';
     case 'no_remote_environment':
       return 'No cloud environment available. Set one up at https://claude.ai/code/onboarding?magic=env-setup';
     case 'not_in_git_repo':

--- a/src/tools/AgentTool/prompt.ts
+++ b/src/tools/AgentTool/prompt.ts
@@ -156,20 +156,20 @@ ${AGENT_TOOL_NAME}({
   const currentExamples = `Example usage:
 
 <example_agent_descriptions>
-"claude-code-guide": use this agent when the user asks how Claude Code works or how to use its features
-"statusline-setup": use this agent to configure the user's Claude Code status line setting
+"claude-code-guide": use this agent when the user asks how Verboo Code works or how to use its features
+"statusline-setup": use this agent to configure the user's Verboo Code status line setting
 </example_agent_descriptions>
 
 <example>
-user: "How do I configure Claude Code hooks?"
+user: "How do I configure Verboo Code hooks?"
 <commentary>
-This is a Claude Code usage question, so use the claude-code-guide agent
+This is a Verboo Code usage question, so use the claude-code-guide agent
 </commentary>
 assistant: Uses the ${AGENT_TOOL_NAME} tool to launch the claude-code-guide agent
 </example>
 
 <example>
-user: "Set up my Claude Code status line"
+user: "Set up my Verboo Code status line"
 <commentary>
 This matches the statusline-setup agent, so use it to configure the setting
 </commentary>

--- a/src/tools/ConfigTool/prompt.ts
+++ b/src/tools/ConfigTool/prompt.ts
@@ -6,7 +6,7 @@ import {
   SUPPORTED_SETTINGS,
 } from './supportedSettings.js'
 
-export const DESCRIPTION = 'Get or set Claude Code configuration settings.'
+export const DESCRIPTION = 'Get or set Verboo Code configuration settings.'
 
 /**
  * Generate the prompt documentation from the registry
@@ -47,9 +47,9 @@ export function generatePrompt(): string {
 
   const modelSection = generateModelSection()
 
-  return `Get or set Claude Code configuration settings.
+  return `Get or set Verboo Code configuration settings.
 
-  View or change Claude Code settings. Use when the user requests configuration changes, asks about current settings, or when adjusting a setting would benefit them.
+  View or change Verboo Code settings. Use when the user requests configuration changes, asks about current settings, or when adjusting a setting would benefit them.
 
 
 ## Usage

--- a/src/tools/FileReadTool/prompt.ts
+++ b/src/tools/FileReadTool/prompt.ts
@@ -37,7 +37,7 @@ Usage:
 - By default, it reads up to ${MAX_LINES_TO_READ} lines starting from the beginning of the file${maxSizeInstruction}
 ${offsetInstruction}
 ${lineFormat}
-- This tool allows Claude Code to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as Claude Code is a multimodal LLM.${
+- This tool allows Verboo Code to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as Verboo Code is a multimodal LLM.${
     isPDFSupported()
       ? '\n- This tool can read PDF files (.pdf). For large PDFs (more than 10 pages), you MUST provide the pages parameter to read specific page ranges (e.g., pages: "1-5"). Reading a large PDF without the pages parameter will fail. Maximum 20 pages per request.'
       : ''

--- a/src/tools/RemoteTriggerTool/prompt.ts
+++ b/src/tools/RemoteTriggerTool/prompt.ts
@@ -1,7 +1,7 @@
 export const REMOTE_TRIGGER_TOOL_NAME = 'RemoteTrigger'
 
 export const DESCRIPTION =
-  'Manage scheduled remote Claude Code agents (triggers) via the claude.ai CCR API. Auth is handled in-process — the token never reaches the shell.'
+  'Manage scheduled remote Verboo Code agents (triggers) via the claude.ai CCR API. Auth is handled in-process — the token never reaches the shell.'
 
 export const PROMPT = `Call the claude.ai remote-trigger API. Use this instead of curl — the OAuth token is added automatically in-process and never exposed.
 

--- a/src/tools/ScheduleCronTool/prompt.ts
+++ b/src/tools/ScheduleCronTool/prompt.ts
@@ -64,17 +64,17 @@ export const CRON_LIST_TOOL_NAME = 'CronList'
 export function buildCronCreateDescription(durableEnabled: boolean): string {
   return durableEnabled
     ? 'Schedule a prompt to run at a future time — either recurring on a cron schedule, or once at a specific time. Pass durable: true to persist to .claude/scheduled_tasks.json; otherwise session-only.'
-    : 'Schedule a prompt to run at a future time within this Claude session — either recurring on a cron schedule, or once at a specific time.'
+    : 'Schedule a prompt to run at a future time within this Verboo session — either recurring on a cron schedule, or once at a specific time.'
 }
 
 export function buildCronCreatePrompt(durableEnabled: boolean): string {
   const durabilitySection = durableEnabled
     ? `## Durability
 
-By default (durable: false) the job lives only in this Claude session — nothing is written to disk, and the job is gone when Claude exits. Pass durable: true to write to .claude/scheduled_tasks.json so the job survives restarts. Only use durable: true when the user explicitly asks for the task to persist ("keep doing this every day", "set this up permanently"). Most "remind me in 5 minutes" / "check back in an hour" requests should stay session-only.`
+By default (durable: false) the job lives only in this Verboo session — nothing is written to disk, and the job is gone when Verboo exits. Pass durable: true to write to .claude/scheduled_tasks.json so the job survives restarts. Only use durable: true when the user explicitly asks for the task to persist ("keep doing this every day", "set this up permanently"). Most "remind me in 5 minutes" / "check back in an hour" requests should stay session-only.`
     : `## Session-only
 
-Jobs live only in this Claude session — nothing is written to disk, and the job is gone when Claude exits.`
+Jobs live only in this Verboo session — nothing is written to disk, and the job is gone when Verboo exits.`
 
   const durableRuntimeNote = durableEnabled
     ? 'Durable jobs persist to .claude/scheduled_tasks.json and survive session restarts — on next launch they resume automatically. One-shot durable tasks that were missed while the REPL was closed are surfaced for catch-up. Session-only jobs die with the process. '

--- a/src/tools/SendMessageTool/prompt.ts
+++ b/src/tools/SendMessageTool/prompt.ts
@@ -4,7 +4,7 @@ export const DESCRIPTION = 'Send a message to another agent'
 
 export function getPrompt(): string {
   const udsRow = feature('UDS_INBOX')
-    ? `\n| \`"uds:/path/to.sock"\` | Local Claude session's socket (same machine; use \`ListPeers\`) |
+    ? `\n| \`"uds:/path/to.sock"\` | Local Verboo session's socket (same machine; use \`ListPeers\`) |
 | \`"bridge:session_..."\` | Remote Control peer session (cross-machine; use \`ListPeers\`) |`
     : ''
   const udsSection = feature('UDS_INBOX')

--- a/src/tools/WebSearchTool/prompt.ts
+++ b/src/tools/WebSearchTool/prompt.ts
@@ -5,10 +5,10 @@ export const WEB_SEARCH_TOOL_NAME = 'WebSearch'
 export function getWebSearchPrompt(): string {
   const currentMonthYear = getLocalMonthYear()
   return `
-- Allows Claude to search the web and use the results to inform responses
+- Allows Verboo to search the web and use the results to inform responses
 - Provides up-to-date information for current events and recent data
 - Returns search result information formatted as search result blocks, including links as markdown hyperlinks
-- Use this tool for accessing information beyond Claude's knowledge cutoff
+- Use this tool for accessing information beyond Verboo's knowledge cutoff
 - Searches are performed automatically within a single API call
 
 CRITICAL REQUIREMENT - You MUST follow this:

--- a/src/utils/claudeDesktop.ts
+++ b/src/utils/claudeDesktop.ts
@@ -15,7 +15,7 @@ export async function getClaudeDesktopConfigPath(): Promise<string> {
 
   if (!SUPPORTED_PLATFORMS.includes(platform)) {
     throw new Error(
-      `Unsupported platform: ${platform} - Claude Desktop integration only works on macOS and WSL.`,
+      `Unsupported platform: ${platform} - Verboo Desktop integration only works on macOS and WSL.`,
     )
   }
 
@@ -91,7 +91,7 @@ export async function getClaudeDesktopConfigPath(): Promise<string> {
   }
 
   throw new Error(
-    'Could not find Claude Desktop config file in Windows. Make sure Claude Desktop is installed on Windows.',
+    'Could not find Verboo Desktop config file in Windows. Make sure Verboo Desktop is installed on Windows.',
   )
 }
 
@@ -100,7 +100,7 @@ export async function readClaudeDesktopMcpServers(): Promise<
 > {
   if (!SUPPORTED_PLATFORMS.includes(getPlatform())) {
     throw new Error(
-      'Unsupported platform - Claude Desktop integration only works on macOS and WSL.',
+      'Unsupported platform - Verboo Desktop integration only works on macOS and WSL.',
     )
   }
   try {

--- a/src/utils/claudeInChrome/setup.ts
+++ b/src/utils/claudeInChrome/setup.ts
@@ -193,7 +193,7 @@ export async function installChromeNativeHostManifest(
 ): Promise<void> {
   const manifestDirs = getNativeMessagingHostsDirs()
   if (manifestDirs.length === 0) {
-    throw Error('Claude in Chrome Native Host not supported on this platform')
+    throw Error('Verboo in Chrome Native Host not supported on this platform')
   }
 
   const manifest = {

--- a/src/utils/computerUse/cleanup.ts
+++ b/src/utils/computerUse/cleanup.ts
@@ -79,7 +79,7 @@ export async function cleanupComputerUseAfterTurn(
 
   if (await releaseComputerUseLock()) {
     ctx.sendOSNotification?.({
-      message: 'Claude is done using your computer',
+      message: 'Verboo is done using your computer',
       notificationType: 'computer_use_exit',
     })
   }

--- a/src/utils/computerUse/wrapper.tsx
+++ b/src/utils/computerUse/wrapper.tsx
@@ -54,7 +54,7 @@ function tuc(): ToolUseContext {
   return currentToolUseContext!;
 }
 function formatLockHeld(holder: string): string {
-  return `Computer use is in use by another Claude session (${holder.slice(0, 8)}…). Wait for that session to finish or run /exit there.`;
+  return `Computer use is in use by another Verboo session (${holder.slice(0, 8)}…). Wait for that session to finish or run /exit there.`;
 }
 export function buildSessionContext(): ComputerUseSessionContext {
   return {
@@ -219,7 +219,7 @@ export function buildSessionContext(): ComputerUseSessionContext {
           tuc().abortController.abort();
         });
         tuc().sendOSNotification?.({
-          message: escRegistered ? 'Claude is using your computer · press Esc to stop' : 'Claude is using your computer · press Ctrl+C to stop',
+          message: escRegistered ? 'Verboo is using your computer · press Esc to stop' : 'Verboo is using your computer · press Ctrl+C to stop',
           notificationType: 'computer_use_enter'
         });
       }

--- a/src/utils/desktopDeepLink.ts
+++ b/src/utils/desktopDeepLink.ts
@@ -216,7 +216,7 @@ export async function openCurrentSessionInDesktop(): Promise<{
     return {
       success: false,
       error:
-        'Claude Desktop is not installed. Install it from https://claude.ai/download',
+        'Verboo Desktop is not installed. Install it from https://claude.ai/download',
     }
   }
 
@@ -227,7 +227,7 @@ export async function openCurrentSessionInDesktop(): Promise<{
   if (!opened) {
     return {
       success: false,
-      error: 'Failed to open Claude Desktop. Please try opening it manually.',
+      error: 'Failed to open Verboo Desktop. Please try opening it manually.',
       deepLinkUrl,
     }
   }

--- a/src/utils/teleport.tsx
+++ b/src/utils/teleport.tsx
@@ -438,7 +438,7 @@ export async function teleportResumeCodeSession(sessionId: string, onProgress?: 
       logEvent('tengu_teleport_resume_error', {
         error_type: 'no_access_token' as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
       });
-      throw new Error('Claude Code web sessions require authentication with a Claude.ai account. API key authentication is not sufficient. Please run /login to authenticate, or check your authentication status with /status.');
+      throw new Error('Verboo Code web sessions require authentication with a Verboo account. API key authentication is not sufficient. Please run /login to authenticate, or check your authentication status with /status.');
     }
 
     // Get organization UUID
@@ -608,7 +608,7 @@ export async function teleportFromSessionsAPI(sessionId: string, orgUUID: string
       logEvent('tengu_teleport_error_session_not_found_404', {
         sessionId: sessionId as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
       });
-      throw new TeleportOperationError(`${sessionId} not found.`, `${sessionId} not found.\n${chalk.dim('Run /status in Claude Code to check your account.')}`);
+      throw new TeleportOperationError(`${sessionId} not found.`, `${sessionId} not found.\n${chalk.dim('Run /status in Verboo Code to check your account.')}`);
     }
     logError(err);
     throw new Error(`Failed to fetch session from Sessions API: ${err.message}`);

--- a/src/utils/teleport/api.ts
+++ b/src/utils/teleport/api.ts
@@ -185,7 +185,7 @@ export async function prepareApiRequest(): Promise<{
   const accessToken = getClaudeAIOAuthTokens()?.accessToken
   if (accessToken === undefined) {
     throw new Error(
-      'Claude Code web sessions require authentication with a Claude.ai account. API key authentication is not sufficient. Please run /login to authenticate, or check your authentication status with /status.',
+      'Verboo Code web sessions require authentication with a Verboo account. API key authentication is not sufficient. Please run /login to authenticate, or check your authentication status with /status.',
     )
   }
 

--- a/src/utils/teleport/environments.ts
+++ b/src/utils/teleport/environments.ts
@@ -33,7 +33,7 @@ export async function fetchEnvironments(): Promise<EnvironmentResource[]> {
   const accessToken = getClaudeAIOAuthTokens()?.accessToken
   if (!accessToken) {
     throw new Error(
-      'Claude Code web sessions require authentication with a Claude.ai account. API key authentication is not sufficient. Please run /login to authenticate, or check your authentication status with /status.',
+      'Verboo Code web sessions require authentication with a Verboo account. API key authentication is not sufficient. Please run /login to authenticate, or check your authentication status with /status.',
     )
   }
 


### PR DESCRIPTION
## Summary

- Substitui strings visíveis ao usuário que mencionam "Claude", "Claude Code", "Claude Desktop" e "Anthropic" por "Verboo" / "Verboo Code" / "Verboo Desktop"
- Cobre: tool prompts (WebSearch, Config, FileRead, ScheduleCron, RemoteTrigger, SendMessage, AgentTool), mensagens de erro (claudeDesktop, desktopDeepLink, teleport, computerUse), CLI help text e .env.example comentários

## O que NÃO mudou (intencional)
- Nomes de funções internas (`getAnthropicClient`, etc.)
- Variáveis de ambiente (`ANTHROPIC_API_KEY`, `CLAUDE_CODE_*`)
- Model names (`claude-sonnet-4-5`, `Claude Opus 4.6`, etc.)
- URLs externas (`claude.ai`, `anthropic.com`)

## Test plan
- [x] `bun run build` passa sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)