### PR TITLE
feat: expose image attachments in UserPromptSubmit hook and bundle vision-fallback plugin

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,108 @@
+# Hooks
+
+Verboo Code supports lifecycle hooks that run shell commands, LLM prompts, HTTP requests, or agentic verifiers at specific points during a session.
+
+## Configuration
+
+Hooks are configured in `~/.verboo/settings.json` under the `hooks` key:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'user submitted a prompt'",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Events
+
+See `src/entrypoints/sdk/coreTypes.ts` for the full list of hook events.
+
+## `UserPromptSubmit` input
+
+The `UserPromptSubmit` hook receives the following input as JSON on stdin:
+
+```ts
+{
+  session_id: string
+  transcript_path: string
+  cwd: string
+  permission_mode?: string
+  agent_id?: string
+  agent_type?: string
+  hook_event_name: 'UserPromptSubmit'
+  prompt: string
+  attachments?: Array<{
+    type: 'image'
+    source: 'base64' | 'file'
+    mediaType: string
+    data?: string      // base64 data when source is 'base64'
+    path?: string      // absolute file path when source is 'file'
+    filename?: string
+  }>
+}
+```
+
+### Image attachments
+
+When the user submits a prompt with image attachments (paste, drag-and-drop, or bridge), the `attachments` field is populated with metadata for each image. Hooks can use this data to call vision models, resize images, or extract text before the main model sees the prompt.
+
+`attachments` is only present when the prompt includes at least one image. Hooks that do not need image data can ignore the field safely.
+
+### Example: vision fallback hook
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ~/.verboo/plugins/vision-fallback/runtime.js",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The command receives the hook input JSON on stdin and should print a JSON object to stdout. To inject context before the main model responds, use:
+
+```json
+{
+  "hookSpecificOutput": {
+    "additionalContext": "Description of the attached image."
+  }
+}
+```
+
+## Output format
+
+Hook commands should print a single JSON object to stdout. Common fields:
+
+| Field | Description |
+|---|---|
+| `hookSpecificOutput.additionalContext` | Injected into the model context (UserPromptSubmit only) |
+| `systemMessage` | Shown to the user as a system message |
+| `blockingError` | Blocks the operation and shows an error |
+| `preventContinuation` | Stops processing but keeps the prompt in context |
+
+## Built-in plugins with hooks
+
+Some bundled plugins register hooks automatically:
+
+- `vision-fallback` — describes image attachments for text-only models using `ultra/qwen3.6-27b` and `ultra/kimi-k2.7`.

--- a/scripts/generate-sdk-types.ts
+++ b/scripts/generate-sdk-types.ts
@@ -108,6 +108,7 @@ const EXPORT_ORDER = [
   'PostToolUseFailureHookInputSchema',
   'PermissionDeniedHookInputSchema',
   'NotificationHookInputSchema',
+  'HookAttachmentSchema',
   'UserPromptSubmitHookInputSchema',
   'SessionStartHookInputSchema',
   'SessionEndHookInputSchema',

--- a/src/entrypoints/sdk/coreSchemas.ts
+++ b/src/entrypoints/sdk/coreSchemas.ts
@@ -481,11 +481,25 @@ export const NotificationHookInputSchema = lazySchema(() =>
   ),
 )
 
+export const HookAttachmentSchema = lazySchema(() =>
+  z.object({
+    type: z.literal('image'),
+    source: z.enum(['base64', 'file']),
+    mediaType: z.string(),
+    data: z.string().optional().describe('Base64-encoded image data when source is base64.'),
+    path: z.string().optional().describe('Absolute file path when source is file.'),
+    filename: z.string().optional(),
+  }),
+)
+
 export const UserPromptSubmitHookInputSchema = lazySchema(() =>
   BaseHookInputSchema().and(
     z.object({
       hook_event_name: z.literal('UserPromptSubmit'),
       prompt: z.string(),
+      attachments: z.array(HookAttachmentSchema()).optional().describe(
+        'Image attachments submitted by the user. Present only when the prompt includes images.',
+      ),
     }),
   ),
 )

--- a/src/entrypoints/sdk/coreTypes.generated.ts
+++ b/src/entrypoints/sdk/coreTypes.generated.ts
@@ -373,6 +373,15 @@ export type NotificationHookInput = {
   notification_type: string
 }
 
+export type HookAttachment = {
+  type: "image"
+  source: "base64" | "file"
+  mediaType: string
+  data?: string
+  path?: string
+  filename?: string
+}
+
 export type UserPromptSubmitHookInput = {
   session_id: string
   transcript_path: string
@@ -383,6 +392,14 @@ export type UserPromptSubmitHookInput = {
 } & {
   hook_event_name: "UserPromptSubmit"
   prompt: string
+  attachments?: {
+    type: "image"
+    source: "base64" | "file"
+    mediaType: string
+    data?: string
+    path?: string
+    filename?: string
+  }[]
 }
 
 export type SessionStartHookInput = {
@@ -789,6 +806,14 @@ export type HookInput = ({
 } & {
   hook_event_name: "UserPromptSubmit"
   prompt: string
+  attachments?: {
+    type: "image"
+    source: "base64" | "file"
+    mediaType: string
+    data?: string
+    path?: string
+    filename?: string
+  }[]
 }) | ({
   session_id: string
   transcript_path: string

--- a/src/plugins/bundled/index.ts
+++ b/src/plugins/bundled/index.ts
@@ -15,10 +15,12 @@
  */
 
 import { registerKarpathyGuidelinesPlugin } from './karpathyGuidelines.js'
+import { registerVisionFallbackPlugin } from './vision-fallback/index.js'
 
 /**
  * Initialize built-in plugins. Called during CLI startup.
  */
 export function initBuiltinPlugins(): void {
   registerKarpathyGuidelinesPlugin()
+  registerVisionFallbackPlugin()
 }

--- a/src/plugins/bundled/vision-fallback/README.md
+++ b/src/plugins/bundled/vision-fallback/README.md
@@ -1,0 +1,29 @@
+# vision-fallback (built-in plugin)
+
+Built-in Verboo Code plugin that gives text-only models the ability to process images.
+
+When a user submits a prompt with image attachments, the `UserPromptSubmit` hook sends the images to a vision-capable model (`ultra/qwen3.6-27b` by default, with `ultra/kimi-k2.7` as fallback) and injects the resulting description into the main model's context via `additionalContext`.
+
+## Behavior
+
+- No-op when the prompt has no image attachments.
+- Uses `ultra/qwen3.6-27b` as the primary vision model.
+- Falls back to `ultra/kimi-k2.7` if the primary model fails or times out.
+- Fails open: if all vision models fail, a short warning is injected and the main model continues.
+
+## Configuration
+
+Environment variables (all optional):
+
+| Variable | Default | Description |
+|---|---|---|
+| `VERBOO_VISION_PRIMARY_MODEL` | `ultra/qwen3.6-27b` | Primary vision model |
+| `VERBOO_VISION_FALLBACK_MODEL` | `ultra/kimi-k2.7` | Fallback vision model |
+| `VERBOO_VISION_BASE_URL` | `https://code.verboo.ai/router/v1` | OpenAI-compatible router endpoint |
+| `VISION_API_KEY` | resolved from `opencode.json` | Router API key |
+
+## Files
+
+- `index.ts` — plugin registration
+- `runtime.ts` — hook command that calls the vision models
+- `__tests__/visionFallback.test.ts` — unit tests

--- a/src/plugins/bundled/vision-fallback/index.ts
+++ b/src/plugins/bundled/vision-fallback/index.ts
@@ -1,0 +1,47 @@
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { registerBuiltinPlugin } from '../../builtinPlugins.js'
+
+const VISION_FALLBACK_SYSTEM_PROMPT = `You are a vision assistant running inside a UserPromptSubmit hook.
+
+When the hook input contains \`attachments\` with images, describe each image accurately and concisely. Then return ONLY a JSON object in this exact format:
+
+{\n  "hookSpecificOutput": {\n    "additionalContext": "[img1] <description>\\n[img2] <description>"\n  }\n}\n
+If there are no attachments, return:
+
+{\n  "hookSpecificOutput": {}\n}\n
+If you cannot describe the images, return:
+
+{\n  "hookSpecificOutput": {\n    "additionalContext": "Aviso: não foi possível descrever a imagem anexada."\n  }\n}\n
+Do not include markdown code fences, explanations, or any text outside the JSON object.`
+
+const runtimePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'runtime.js',
+)
+
+export function registerVisionFallbackPlugin(): void {
+  registerBuiltinPlugin({
+    name: 'vision-fallback',
+    description:
+      'Gives text-only models the ability to process images by describing them with a vision model before the main model responds.',
+    version: '0.1.0',
+    defaultEnabled: true,
+    hooks: {
+      UserPromptSubmit: [
+        {
+          hooks: [
+            {
+              type: 'command',
+              command: `node "${runtimePath}"`,
+              timeout: 60,
+              statusMessage: 'Analyzing image with vision fallback...',
+            },
+          ],
+        },
+      ],
+    },
+  })
+}
+
+export { VISION_FALLBACK_SYSTEM_PROMPT }

--- a/src/plugins/bundled/vision-fallback/runtime.ts
+++ b/src/plugins/bundled/vision-fallback/runtime.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * Vision fallback runtime for the bundled plugin.
+ *
+ * Reads a UserPromptSubmit hook input from stdin, describes any image
+ * attachments via the Verboo router, and writes hook output to stdout.
+ */
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const DEFAULT_PRIMARY_MODEL = 'ultra/qwen3.6-27b'
+const DEFAULT_FALLBACK_MODEL = 'ultra/kimi-k2.7'
+const PER_MODEL_TIMEOUT_MS = 30_000
+const TOTAL_TIMEOUT_MS = 60_000
+
+interface HookAttachment {
+  type: 'image'
+  source: 'base64' | 'file'
+  mediaType: string
+  data?: string
+  path?: string
+  filename?: string
+}
+
+interface HookInput {
+  hook_event_name: string
+  prompt: string
+  cwd: string
+  attachments?: HookAttachment[]
+}
+
+interface VisionModel {
+  id: string
+}
+
+function logError(message: string): void {
+  // eslint-disable-next-line no-console
+  console.error(`[vision-fallback] ${message}`)
+}
+
+function getEnv(name: string): string | undefined {
+  return process.env[name]
+}
+
+export function resolveApiKey(cwd: string): string | undefined {
+  const envKey = getEnv('VISION_API_KEY')
+  if (envKey && envKey.length > 0) return envKey
+
+  const candidates = [
+    join(cwd, 'opencode.json'),
+    join(homedir(), '.config', 'opencode', 'opencode.json'),
+    join(homedir(), '.verboo', 'opencode.json'),
+  ]
+
+  for (const path of candidates) {
+    try {
+      const raw = readFileSync(path, 'utf8')
+      const parsed = JSON.parse(raw) as {
+        provider?: { verboo?: { options?: { apiKey?: string } } }
+      }
+      const key = parsed.provider?.verboo?.options?.apiKey
+      if (key) return key
+    } catch {
+      // ignore missing or invalid config
+    }
+  }
+
+  return undefined
+}
+
+function buildVisionModels(): VisionModel[] {
+  const primary = getEnv('VERBOO_VISION_PRIMARY_MODEL') ?? DEFAULT_PRIMARY_MODEL
+  const fallback = getEnv('VERBOO_VISION_FALLBACK_MODEL') ?? DEFAULT_FALLBACK_MODEL
+  return [
+    { id: primary },
+    ...fallback
+      .split(/[\s,]+/)
+      .map(id => id.trim())
+      .filter(Boolean)
+      .filter(id => id !== primary)
+      .map(id => ({ id })),
+  ]
+}
+
+async function describeWithModel(
+  model: VisionModel,
+  apiKey: string,
+  attachments: HookAttachment[],
+  signal: AbortSignal,
+): Promise<string> {
+  const baseURL =
+    getEnv('VERBOO_VISION_BASE_URL') ?? 'https://code.verboo.ai/router/v1'
+  const messages: Array<{
+    role: 'user'
+    content: Array<
+      | { type: 'text'; text: string }
+      | { type: 'image_url'; image_url: { url: string } }
+    >
+  }> = [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'Descreva cada imagem em português de forma clara e concisa. Se for screenshot de interface, descreva os elementos visuais, textos e layout.',
+        },
+        ...attachments.map(attachment => {
+          const url =
+            attachment.source === 'file' && attachment.path
+              ? `file://${attachment.path}`
+              : `data:${attachment.mediaType};base64,${attachment.data ?? ''}`
+          return {
+            type: 'image_url' as const,
+            image_url: { url },
+          }
+        }),
+      ],
+    },
+  ]
+
+  const response = await fetch(`${baseURL}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: model.id,
+      messages,
+      max_tokens: 1024,
+    }),
+    signal,
+  })
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${await response.text()}`)
+  }
+
+  const data = (await response.json()) as {
+    choices?: Array<{ message?: { content?: string | Array<{ type?: string; text?: string }> } }>
+  }
+  const content = data.choices?.[0]?.message?.content
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content.map(part => part.text ?? '').join('')
+  }
+  throw new Error('Empty response from vision model')
+}
+
+export async function describeAttachments(
+  input: HookInput,
+  injectedApiKey?: string,
+): Promise<{ additionalContext?: string }> {
+  const attachments = input.attachments?.filter(a => a.type === 'image')
+  if (!attachments || attachments.length === 0) {
+    return {}
+  }
+
+  const apiKey = injectedApiKey ?? resolveApiKey(input.cwd)
+  if (!apiKey) {
+    return {
+      additionalContext:
+        'Aviso: não foi possível descrever a imagem anexada (credencial do router não encontrada).',
+    }
+  }
+
+  const models = buildVisionModels()
+  const startedAt = Date.now()
+  const errors: string[] = []
+
+  for (const model of models) {
+    const remainingMs = TOTAL_TIMEOUT_MS - (Date.now() - startedAt)
+    const timeoutMs = Math.min(PER_MODEL_TIMEOUT_MS, Math.max(remainingMs - 2000, 1000))
+    if (timeoutMs <= 0) break
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+    try {
+      const description = await describeWithModel(
+        model,
+        apiKey,
+        attachments,
+        controller.signal,
+      )
+      clearTimeout(timer)
+      return { additionalContext: description }
+    } catch (error) {
+      clearTimeout(timer)
+      const message = error instanceof Error ? error.message : String(error)
+      errors.push(`${model.id}: ${message}`)
+    }
+  }
+
+  return {
+    additionalContext: `Aviso: não foi possível descrever a imagem anexada (${errors.join('; ')}).`,
+  }
+}
+
+async function main(): Promise<void> {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk)
+  }
+  const input = JSON.parse(Buffer.concat(chunks).toString('utf8')) as HookInput
+
+  const result = await describeAttachments(input)
+
+  const output = result.additionalContext
+    ? { hookSpecificOutput: { additionalContext: result.additionalContext } }
+    : {}
+
+  process.stdout.write(JSON.stringify(output))
+}
+
+main().catch(error => {
+  logError(error instanceof Error ? error.message : String(error))
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        additionalContext:
+          'Aviso: não foi possível descrever a imagem anexada (erro interno no vision-fallback).',
+      },
+    }),
+  )
+})

--- a/src/plugins/bundled/visionFallback.test.ts
+++ b/src/plugins/bundled/visionFallback.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
+import { registerVisionFallbackPlugin } from './vision-fallback/index.js'
+import { getBuiltinPluginDefinition } from '../builtinPlugins.js'
+import { describeAttachments } from './vision-fallback/runtime.js'
+
+describe('vision-fallback bundled plugin', () => {
+  beforeEach(() => {
+    registerVisionFallbackPlugin()
+  })
+
+  it('registers a builtin plugin named vision-fallback', () => {
+    const definition = getBuiltinPluginDefinition('vision-fallback')
+    expect(definition).toBeDefined()
+    expect(definition!.name).toBe('vision-fallback')
+    expect(definition!.defaultEnabled).toBe(true)
+  })
+
+  it('registers a UserPromptSubmit command hook', () => {
+    const definition = getBuiltinPluginDefinition('vision-fallback')
+    const matchers = definition!.hooks?.UserPromptSubmit
+    expect(matchers).toBeDefined()
+    expect(matchers).toHaveLength(1)
+    const hook = matchers![0].hooks[0]
+    expect(hook.type).toBe('command')
+    expect(hook.timeout).toBe(60)
+    expect(hook.statusMessage).toBe('Analyzing image with vision fallback...')
+  })
+})
+
+describe('vision-fallback runtime', () => {
+  const originalFetch = globalThis.fetch
+  const originalVisionApiKey = process.env.VISION_API_KEY
+  const originalPrimaryModel = process.env.VERBOO_VISION_PRIMARY_MODEL
+  const originalFallbackModel = process.env.VERBOO_VISION_FALLBACK_MODEL
+  const originalBaseUrl = process.env.VERBOO_VISION_BASE_URL
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    process.env.VISION_API_KEY = originalVisionApiKey
+    process.env.VERBOO_VISION_PRIMARY_MODEL = originalPrimaryModel
+    process.env.VERBOO_VISION_FALLBACK_MODEL = originalFallbackModel
+    process.env.VERBOO_VISION_BASE_URL = originalBaseUrl
+  })
+
+  it('no-op when there are no attachments', async () => {
+    const result = await describeAttachments({
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'hello',
+      cwd: 'C:/tmp/vision-fallback-test-cwd',
+    })
+    expect(result.additionalContext).toBeUndefined()
+  })
+
+  it('returns warning when API key is missing', async () => {
+    const result = await describeAttachments(
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: '[Image #1]',
+        cwd: 'C:/tmp/vision-fallback-test-cwd',
+        attachments: [
+          {
+            type: 'image',
+            source: 'base64',
+            mediaType: 'image/png',
+            data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+          },
+        ],
+      },
+      '',
+    )
+    expect(result.additionalContext).toContain('credencial do router não encontrada')
+  })
+
+  it('describes image using primary model', async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: 'Um cachorro marrom.' } }],
+        }),
+        { status: 200 },
+      ) as unknown as Response
+
+    const result = await describeAttachments(
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: '[Image #1]',
+        cwd: 'C:/tmp/vision-fallback-test-cwd',
+        attachments: [
+          {
+            type: 'image',
+            source: 'base64',
+            mediaType: 'image/png',
+            data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+          },
+        ],
+      },
+      'test-key',
+    )
+    expect(result.additionalContext).toBe('Um cachorro marrom.')
+  })
+
+  it('falls back to secondary model when primary fails', async () => {
+    process.env.VERBOO_VISION_PRIMARY_MODEL = 'ultra/failing-model'
+    process.env.VERBOO_VISION_FALLBACK_MODEL = 'ultra/kimi-k2.7'
+
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse((init as { body: string }).body)
+      if (body.model === 'ultra/failing-model') {
+        return new Response('Internal Server Error', { status: 500 }) as unknown as Response
+      }
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: 'Fallback description.' } }],
+        }),
+        { status: 200 },
+      ) as unknown as Response
+    }
+
+    const result = await describeAttachments(
+      {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: '[Image #1]',
+        cwd: 'C:/tmp/vision-fallback-test-cwd',
+        attachments: [
+          {
+            type: 'image',
+            source: 'base64',
+            mediaType: 'image/png',
+            data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+          },
+        ],
+      },
+      'test-key',
+    )
+    expect(result.additionalContext).toBe('Fallback description.')
+  })
+})

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -4058,6 +4058,32 @@ export async function* executeTaskCompletedHooks(
  * @param toolUseContext ToolUseContext for prompt-based hooks
  * @returns Async generator that yields progress messages and hook results
  */
+export function buildUserPromptSubmitAttachments(
+  pastedContents?: Record<number, import('./config.js').PastedContent>,
+): UserPromptSubmitHookInput['attachments'] {
+  if (!pastedContents) {
+    return undefined
+  }
+
+  const attachments = Object.values(pastedContents)
+    .filter(
+      (
+        content,
+      ): content is import('./config.js').PastedContent & { type: 'image' } =>
+        content.type === 'image',
+    )
+    .map(content => ({
+      type: 'image' as const,
+      source: content.sourcePath ? ('file' as const) : ('base64' as const),
+      mediaType: content.mediaType || 'image/png',
+      data: content.sourcePath ? undefined : content.content,
+      path: content.sourcePath,
+      filename: content.filename,
+    }))
+
+  return attachments.length > 0 ? attachments : undefined
+}
+
 export async function* executeUserPromptSubmitHooks(
   prompt: string,
   permissionMode: string,
@@ -4066,6 +4092,7 @@ export async function* executeUserPromptSubmitHooks(
     sourceName: string,
     toolInputSummary?: string | null,
   ) => (request: PromptRequest) => Promise<PromptResponse>,
+  pastedContents?: Record<number, import('./config.js').PastedContent>,
 ): AsyncGenerator<AggregatedHookResult> {
   const appState = toolUseContext.getAppState()
   const sessionId = toolUseContext.agentId ?? getSessionId()
@@ -4077,6 +4104,7 @@ export async function* executeUserPromptSubmitHooks(
     ...createBaseHookInput(permissionMode),
     hook_event_name: 'UserPromptSubmit',
     prompt,
+    attachments: buildUserPromptSubmitAttachments(pastedContents),
   }
 
   yield* executeHooks({

--- a/src/utils/hooks.userPromptSubmitAttachments.test.ts
+++ b/src/utils/hooks.userPromptSubmitAttachments.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'bun:test'
+import { buildUserPromptSubmitAttachments } from './hooks.js'
+import type { PastedContent } from './config.js'
+
+describe('buildUserPromptSubmitAttachments', () => {
+  it('returns undefined when pastedContents is undefined', () => {
+    expect(buildUserPromptSubmitAttachments(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined when there are no image attachments', () => {
+    const pastedContents: Record<number, PastedContent> = {
+      1: {
+        id: 1,
+        type: 'text',
+        content: 'some pasted text',
+      },
+    }
+    expect(buildUserPromptSubmitAttachments(pastedContents)).toBeUndefined()
+  })
+
+  it('builds base64 attachment from pasted image content', () => {
+    const pastedContents: Record<number, PastedContent> = {
+      1: {
+        id: 1,
+        type: 'image',
+        content: 'base64data',
+        mediaType: 'image/png',
+        filename: 'screenshot.png',
+      },
+    }
+    const attachments = buildUserPromptSubmitAttachments(pastedContents)
+    expect(attachments).toHaveLength(1)
+    expect(attachments![0]).toEqual({
+      type: 'image',
+      source: 'base64',
+      mediaType: 'image/png',
+      data: 'base64data',
+      path: undefined,
+      filename: 'screenshot.png',
+    })
+  })
+
+  it('builds file attachment when sourcePath is present', () => {
+    const pastedContents: Record<number, PastedContent> = {
+      1: {
+        id: 1,
+        type: 'image',
+        content: 'base64data',
+        mediaType: 'image/jpeg',
+        sourcePath: '/tmp/photo.jpg',
+        filename: 'photo.jpg',
+      },
+    }
+    const attachments = buildUserPromptSubmitAttachments(pastedContents)
+    expect(attachments).toHaveLength(1)
+    expect(attachments![0]).toEqual({
+      type: 'image',
+      source: 'file',
+      mediaType: 'image/jpeg',
+      data: undefined,
+      path: '/tmp/photo.jpg',
+      filename: 'photo.jpg',
+    })
+  })
+
+  it('filters out non-image pasted contents', () => {
+    const pastedContents: Record<number, PastedContent> = {
+      1: {
+        id: 1,
+        type: 'text',
+        content: 'some text',
+      },
+      2: {
+        id: 2,
+        type: 'image',
+        content: 'base64data',
+        mediaType: 'image/png',
+      },
+    }
+    const attachments = buildUserPromptSubmitAttachments(pastedContents)
+    expect(attachments).toHaveLength(1)
+    expect(attachments![0].type).toBe('image')
+  })
+
+  it('defaults mediaType to image/png when missing', () => {
+    const pastedContents: Record<number, PastedContent> = {
+      1: {
+        id: 1,
+        type: 'image',
+        content: 'base64data',
+      },
+    }
+    const attachments = buildUserPromptSubmitAttachments(pastedContents)
+    expect(attachments![0].mediaType).toBe('image/png')
+  })
+})

--- a/src/utils/processUserInput/processUserInput.ts
+++ b/src/utils/processUserInput/processUserInput.ts
@@ -184,6 +184,7 @@ export async function processUserInput({
     appState.toolPermissionContext.mode,
     context,
     context.requestPrompt,
+    pastedContents,
   )) {
     // We only care about the result
     if (hookResult.message?.type === 'progress') {


### PR DESCRIPTION
## Summary

This PR enables text-only models in Verboo Code to process image attachments by:

1. Exposing image attachments in the `UserPromptSubmit` hook input.
2. Bundling a `vision-fallback` plugin that automatically describes images using `ultra/qwen3.6-27b` (primary) and `ultra/kimi-k2.7` (fallback) before the main model responds.

## Motivation

Models like `glm-5.2`, `deepseek-v4-flash`, `deepseek-v4-pro`, and `mimo-v2.5-pro` do not support vision. When a user pastes an image while one of these models is active, the image is silently ignored or the model only sees a placeholder like `[Image #1]`.

The OpenCode ecosystem already demonstrates this pattern in [`opencode-see-image`](https://github.com/alfaoz/opencode-see-image). I also built a working local plugin ([`NatanPimentel/verboo-vision-fallback`](https://github.com/NatanPimentel/verboo-vision-fallback)), but it requires manual hook registration in `~/.verboo/settings.json` because the hook input does not carry attachment data.

## Changes

### Core

- `src/entrypoints/sdk/coreSchemas.ts`: added `HookAttachmentSchema` and `attachments` field to `UserPromptSubmitHookInputSchema`.
- `src/entrypoints/sdk/coreTypes.generated.ts`: regenerated (56 exports still in sync).
- `src/utils/hooks.ts`: added `buildUserPromptSubmitAttachments()` and wired it into `executeUserPromptSubmitHooks()`.
- `src/utils/processUserInput/processUserInput.ts`: passes `pastedContents` to `executeUserPromptSubmitHooks()`.

### Plugin

- `src/plugins/bundled/vision-fallback/index.ts`: registers the built-in plugin with a `UserPromptSubmit` command hook.
- `src/plugins/bundled/vision-fallback/runtime.ts`: describes images via the Verboo router with fallback and fail-open behavior.
- `src/plugins/bundled/vision-fallback/README.md`: plugin documentation.
- `src/plugins/bundled/index.ts`: initializes the plugin.

### Docs & tests

- `docs/hooks.md`: new documentation for `UserPromptSubmit` hooks and the `attachments` field.
- `src/utils/hooks.userPromptSubmitAttachments.test.ts`: tests for attachment building.
- `src/plugins/bundled/visionFallback.test.ts`: tests for plugin registration and runtime behavior.

## Behavior

- If the prompt has no image attachments, the plugin does nothing (no extra API call).
- If images are present, `qwen3.6-27b` describes them first.
- If `qwen3.6-27b` fails or times out, `kimi-k2.7` is tried.
- If all vision models fail, a short warning is injected and the main model continues.

## Configuration

Optional environment variables:

| Variable | Default |
|---|---|
| `VERBOO_VISION_PRIMARY_MODEL` | `ultra/qwen3.6-27b` |
| `VERBOO_VISION_FALLBACK_MODEL` | `ultra/kimi-k2.7` |
| `VERBOO_VISION_BASE_URL` | `https://code.verboo.ai/router/v1` |
| `VISION_API_KEY` | read from `opencode.json` |

## Verification

- `bun run build` ✅
- `bun run smoke` ✅
- `bun test src/utils/hooks.userPromptSubmitAttachments.test.ts src/plugins/bundled/visionFallback.test.ts` ✅ (12/12 passing)

## Notes

- Issues are disabled on this repository, so I could not open a feature request first as suggested by `CONTRIBUTING.md`. I used the PR body to describe the proposal in detail instead.
- The core change is additive and optional: existing hooks that ignore `attachments` continue to work unchanged.
