### PR TITLE
feat: delegate image analysis to a vision-capable model when the active model lacks vision

### DIFF
--- a/src/hooks/usePasteHandler.test.ts
+++ b/src/hooks/usePasteHandler.test.ts
@@ -16,8 +16,8 @@ test('supports clipboard image fallback on Linux', () => {
   expect(supportsClipboardImageFallback('linux')).toBe(true)
 })
 
-test('does not support clipboard image fallback on WSL', () => {
-  expect(supportsClipboardImageFallback('wsl')).toBe(false)
+test('supports clipboard image fallback on WSL (Windows clipboard via powershell.exe interop)', () => {
+  expect(supportsClipboardImageFallback('wsl')).toBe(true)
 })
 
 test('does not support clipboard image fallback on unknown platforms', () => {

--- a/src/hooks/usePasteHandler.ts
+++ b/src/hooks/usePasteHandler.ts
@@ -18,8 +18,13 @@ const PASTE_COMPLETION_TIMEOUT_MS = 100
 export function supportsClipboardImageFallback(
   platform: ReturnType<typeof getPlatform>,
 ): boolean {
+  // 'wsl' is included: the Windows clipboard is reachable through
+  // powershell.exe interop (see the wsl command set in utils/imagePaste.ts).
   return (
-    platform === 'macos' || platform === 'windows' || platform === 'linux'
+    platform === 'macos' ||
+    platform === 'windows' ||
+    platform === 'linux' ||
+    platform === 'wsl'
   )
 }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -56,6 +56,14 @@ import { buildAnthropicUsageFromRawUsage } from './cacheMetrics.js'
 import { compressToolHistory } from './compressToolHistory.js'
 import { fetchWithProxyRetry } from './fetchWithProxyRetry.js'
 import {
+  delegateImagesInMessages,
+  isVisionDelegationEnabled,
+  messagesContainImages,
+  modelSupportsVision,
+  pickVisionModel,
+  stripResidualImageParts,
+} from './visionDelegate.js'
+import {
   getLocalFastPathConfig,
   getLocalProviderRetryBaseUrls,
   getGithubEndpointType,
@@ -1708,6 +1716,93 @@ class OpenAIShimMessages {
     this.suppressReasoningEffort = suppressReasoningEffort
   }
 
+  /**
+   * Pre-pass for models without vision: replace every image block with a
+   * text analysis produced by a vision-capable router model (one nested,
+   * non-streaming create per unique image group; results are cached).
+   * No-op when delegation is disabled, a provider override is active (local
+   * backends route every model id to the override), the target model has
+   * vision, or there are no images.
+   */
+  private async _maybeDelegateVision(
+    messages: Array<{
+      role: string
+      message?: { role?: string; content?: unknown }
+      content?: unknown
+    }>,
+    resolvedModel: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<
+    Array<{
+      role: string
+      message?: { role?: string; content?: unknown }
+      content?: unknown
+    }>
+  > {
+    if (!isVisionDelegationEnabled()) return messages
+    // Only the Verboo router path can reach the vision-capable router
+    // models — skip for external providers (per-agent local backends, etc.)
+    // and let the belt-and-suspenders strip protect the request.
+    const routerOverride = this.providerOverride
+    if (!routerOverride || !isVerbooRouterUrl(routerOverride.baseURL)) {
+      return messages
+    }
+    // modelSupportsVision returns undefined when the model is not in the
+    // catalog — keep images inline until the catalog is fetched.
+    if (modelSupportsVision(resolvedModel) !== false) return messages
+    if (!messagesContainImages(messages)) return messages
+
+    const visionModel = pickVisionModel()
+    if (!visionModel) {
+      return delegateImagesInMessages(messages, undefined, undefined)
+    }
+
+    const self = new OpenAIShimMessages(this.defaultHeaders, undefined, {
+      ...routerOverride,
+      model: visionModel,
+    })
+    return delegateImagesInMessages(
+      messages,
+      visionModel,
+      async ({ model, images, prompt }) => {
+        const result = await (self.create(
+              {
+                model,
+                max_tokens: 2048,
+                stream: false,
+                messages: [
+                  {
+                    role: 'user',
+                    content: [{ type: 'text', text: prompt }, ...images],
+                  },
+                ],
+              } as ShimCreateParams,
+              { signal: options?.signal },
+            ) as Promise<{ content?: Array<{ type?: string; text?: string }> }>)
+            const text = Array.isArray(result?.content)
+              ? result.content
+                  .filter(block => block?.type === 'text')
+                  .map(block => block.text ?? '')
+                  .join('\n')
+                  .trim()
+              : ''
+            if (!text) {
+              throw new Error(
+                `vision model ${model} returned an empty analysis`,
+              )
+            }
+            return text
+          }
+        : undefined,
+    ) as Promise<
+      Array<{
+        role: string
+        message?: { role?: string; content?: unknown }
+        content?: unknown
+      }>
+    >
+  }
+
   create(
     params: ShimCreateParams,
     options?: { signal?: AbortSignal; headers?: Record<string, string> },
@@ -1921,6 +2016,29 @@ class OpenAIShimMessages {
     const compressedMessages = fastPath.skipToolHistoryCompression
       ? rawMessages
       : compressToolHistory(rawMessages, request.resolvedModel)
+
+    // Vision delegation: if the target model cannot see images, analyze them
+    // once with a vision-capable router model and substitute the text — an
+    // image block sent to a blind model 400s every request from then on
+    // (history is resent each turn). Covers every source: pasted images,
+    // FileRead of images, MCP tool results (browser screenshots), agents.
+    const visionSafeMessages = await this._maybeDelegateVision(
+      compressedMessages,
+      request.resolvedModel,
+      options,
+    )
+    // The `responses` transport serializes from the raw (uncompressed)
+    // messages — delegate those too when that transport is active. The
+    // analysis cache makes the second pass free for already-seen images.
+    const visionSafeRawMessages =
+      request.transport === 'responses'
+        ? await this._maybeDelegateVision(
+            rawMessages,
+            request.resolvedModel,
+            options,
+          )
+        : rawMessages
+
     const runtimeShimContext = resolveOpenAIShimRuntimeContext({
       processEnv: process.env,
       baseUrl: request.baseUrl,
@@ -1928,14 +2046,26 @@ class OpenAIShimMessages {
       treatAsLocal: isLocalProviderUrl(request.baseUrl),
     })
     const shimConfig = runtimeShimContext.openaiShimConfig
-    const openaiMessages = convertMessages(compressedMessages, params.system, {
+    const openaiMessages = convertMessages(visionSafeMessages, params.system, {
       preserveReasoningContent: shimConfig.preserveReasoningContent,
       reasoningContentFallback: shimConfig.reasoningContentFallback,
     })
 
+    // Belt-and-suspenders: if the target model has NO vision, strip any
+    // image_url that might have survived the delegation pre-pass (a sign
+    // that some code path escaped the rewrite). Only on the Verboo router
+    // path — a non-Verboo provider with a coincidental model id must not
+    // be affected.
+    const shouldStrip =
+      isVerbooRouterUrl(request.baseUrl) &&
+      modelSupportsVision(request.resolvedModel) === false
+    const { messages: strippedMessages } = shouldStrip
+      ? stripResidualImageParts(openaiMessages)
+      : { messages: openaiMessages }
+
     const body: Record<string, unknown> = {
       model: request.resolvedModel,
-      messages: openaiMessages,
+      messages: strippedMessages,
       stream: params.stream ?? false,
       store: false,
     }
@@ -2072,7 +2202,7 @@ class OpenAIShimMessages {
       const responsesBody: Record<string, unknown> = {
         model: request.resolvedModel,
         input: convertAnthropicMessagesToResponsesInput(
-          params.messages as Array<{
+          visionSafeRawMessages as Array<{
             role?: string
             message?: { role?: string; content?: unknown }
             content?: unknown

--- a/src/services/api/verbooModels.ts
+++ b/src/services/api/verbooModels.ts
@@ -10,6 +10,7 @@ export type VerbooModel = {
   maxOutputTokens?: number
   displayName?: string
   description?: string
+  vision?: boolean
   reasoning?: VerbooModelReasoning
   raw: Record<string, unknown>
 }
@@ -106,6 +107,7 @@ function normalizeModel(raw: Record<string, unknown>): VerbooModel | null {
     ),
     displayName: pickString(raw, 'display_name', 'displayName', 'label'),
     description: pickString(raw, 'description'),
+    vision: typeof raw.vision === 'boolean' ? raw.vision : undefined,
     reasoning: normalizeReasoning(raw),
     raw,
   }

--- a/src/services/api/visionDelegate.test.ts
+++ b/src/services/api/visionDelegate.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, expect, test } from 'bun:test'
+import {
+  clearVisionAnalysisCache,
+  delegateImagesInMessages,
+  IMAGE_REMOVED_PLACEHOLDER,
+  isVisionDelegationEnabled,
+  messagesContainImages,
+  stripResidualImageParts,
+  visionAnalysisMarker,
+  type VisionCaller,
+} from './visionDelegate.ts'
+
+beforeEach(() => {
+  clearVisionAnalysisCache()
+  delete process.env.VERBOO_VISION_DELEGATE
+})
+
+function imageBlock(data = 'aGVsbG8='): Record<string, unknown> {
+  return {
+    type: 'image',
+    source: { type: 'base64', media_type: 'image/png', data },
+  }
+}
+
+// --- gate ---------------------------------------------------------------
+
+test('delegation is enabled by default and disabled via env', () => {
+  expect(isVisionDelegationEnabled()).toBe(true)
+  process.env.VERBOO_VISION_DELEGATE = 'off'
+  expect(isVisionDelegationEnabled()).toBe(false)
+})
+
+// --- messagesContainImages ----------------------------------------------
+
+test('detects images in user messages and nested tool_results', () => {
+  expect(
+    messagesContainImages([{ role: 'user', content: 'just text' }]),
+  ).toBe(false)
+  expect(
+    messagesContainImages([{ role: 'user', content: [imageBlock()] }]),
+  ).toBe(true)
+  expect(
+    messagesContainImages([
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: [imageBlock()] },
+        ],
+      },
+    ]),
+  ).toBe(true)
+})
+
+// --- delegateImagesInMessages -------------------------------------------
+
+function makeCaller(analysis = 'a red rectangle with TESTE text') {
+  const calls: Array<{ model: string; prompt: string; images: unknown[] }> = []
+  const caller: VisionCaller = async args => {
+    calls.push(args)
+    return analysis
+  }
+  return { caller, calls }
+}
+
+test('replaces a pasted image with the vision analysis and marker', async () => {
+  const { caller, calls } = makeCaller()
+  const messages = [
+    {
+      role: 'user',
+      content: [{ type: 'text', text: 'o que há neste print?' }, imageBlock()],
+    },
+  ]
+
+  const out = await delegateImagesInMessages(messages, 'qwen3.6-27b', caller)
+
+  const content = out[0].content as Array<{ type: string; text?: string }>
+  expect(content.some(b => b.type === 'image')).toBe(false)
+  const injected = content.find(b => b.text?.includes('red rectangle'))
+  expect(injected?.text).toContain(visionAnalysisMarker('qwen3.6-27b'))
+  // user text flows into the delegation prompt as context
+  expect(calls[0].prompt).toContain('o que há neste print?')
+})
+
+test('handles the wrapped .message.content shape', async () => {
+  const { caller } = makeCaller()
+  const messages = [
+    {
+      role: 'user',
+      message: { role: 'user', content: [imageBlock()] },
+    },
+  ]
+  const out = await delegateImagesInMessages(messages, 'v', caller)
+  const content = (out[0].message as { content: Array<{ type: string }> })
+    .content
+  expect(content.some(b => b.type === 'image')).toBe(false)
+})
+
+test('tool_result screenshots are analyzed with the tool name as context', async () => {
+  const { caller, calls } = makeCaller()
+  const messages = [
+    { role: 'user', content: [{ type: 'text', text: 'tira um print do site' }] },
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'tu1', name: 'take_screenshot', input: {} }],
+    },
+    {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'tu1', content: [imageBlock()] },
+      ],
+    },
+  ]
+
+  const out = await delegateImagesInMessages(messages, 'v', caller)
+
+  expect(calls).toHaveLength(1)
+  expect(calls[0].prompt).toContain('take_screenshot')
+  expect(calls[0].prompt).toContain('tira um print do site')
+  const toolResult = (out[2].content as Array<Record<string, unknown>>)[0]
+  const nested = toolResult.content as Array<{ type: string; text?: string }>
+  expect(nested.some(b => b.type === 'image')).toBe(false)
+})
+
+test('multiple images in one tool_result share a single vision call', async () => {
+  const { caller, calls } = makeCaller()
+  const messages = [
+    {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 't1',
+          content: [imageBlock('AAA='), imageBlock('BBB=')],
+        },
+      ],
+    },
+  ]
+
+  const out = await delegateImagesInMessages(messages, 'v', caller)
+
+  expect(calls).toHaveLength(1)
+  expect(calls[0].images).toHaveLength(2)
+  const nested = (out[0].content as Array<Record<string, unknown>>)[0]
+    .content as Array<{ text?: string }>
+  expect(nested[1].text).toContain('combined image analysis')
+})
+
+test('the same image across turns is analyzed only once (history resend)', async () => {
+  const { caller, calls } = makeCaller()
+  const turn = [{ role: 'user', content: [imageBlock('c2FtZQ==')] }]
+
+  await delegateImagesInMessages(turn, 'v', caller)
+  await delegateImagesInMessages(turn, 'v', caller) // next turn resends history
+
+  expect(calls).toHaveLength(1)
+})
+
+test('a failed vision call degrades to a placeholder and never throws', async () => {
+  const caller: VisionCaller = async () => {
+    throw new Error('router unavailable')
+  }
+  const messages = [{ role: 'user', content: [imageBlock()] }]
+
+  const out = await delegateImagesInMessages(messages, 'v', caller)
+
+  const content = out[0].content as Array<{ type: string; text?: string }>
+  expect(content[0].type).toBe('text')
+  expect(content[0].text).toContain('could not be analyzed')
+})
+
+test('messages without images pass through as the same reference', async () => {
+  const { caller, calls } = makeCaller()
+  const messages = [{ role: 'user', content: 'sem imagem' }]
+  const out = await delegateImagesInMessages(messages, 'v', caller)
+  expect(out).toBe(messages)
+  expect(calls).toHaveLength(0)
+})
+
+test('no vision model degrades to placeholder without calling vision', async () => {
+  const caller: VisionCaller = async () => {
+    throw new Error('should not be called')
+  }
+  const messages = [{ role: 'user', content: [imageBlock()] }]
+
+  const out = await delegateImagesInMessages(messages, undefined, undefined)
+
+  const content = out[0].content as Array<{ type: string; text?: string }>
+  expect(content[0].type).toBe('text')
+  expect(content[0].text).toBe(IMAGE_REMOVED_PLACEHOLDER)
+})
+
+// --- stripResidualImageParts --------------------------------------------
+
+test('strips surviving image_url parts and reports the count', () => {
+  const { messages, removed } = stripResidualImageParts([
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'oi' },
+        { type: 'image_url', image_url: { url: 'data:image/png;base64,x' } },
+      ],
+    },
+  ])
+  expect(removed).toBe(1)
+  const parts = messages[0].content as Array<{ type: string; text?: string }>
+  expect(parts.some(p => p.type === 'image_url')).toBe(false)
+  expect(parts[1].text).toBe(IMAGE_REMOVED_PLACEHOLDER)
+})
+
+test('is a no-op (same reference) when nothing image-shaped survived', () => {
+  const input = [{ role: 'user', content: 'texto' }]
+  const { messages, removed } = stripResidualImageParts(input)
+  expect(removed).toBe(0)
+  expect(messages).toBe(input)
+})

--- a/src/services/api/visionDelegate.ts
+++ b/src/services/api/visionDelegate.ts
@@ -1,0 +1,404 @@
+import { createHash } from 'crypto'
+import { logForDebugging } from '../../utils/debug.js'
+import {
+  getCachedVerbooModels,
+  getVerbooModelMeta,
+} from './verbooModels.js'
+
+/**
+ * Vision delegation: guarantees that no image block ever reaches a model
+ * without vision support. When the active model lacks vision, every image in
+ * the outgoing message array (pasted screenshots, FileRead of images, MCP tool
+ * results such as browser screenshots) is analyzed once by a vision-capable
+ * router model and replaced by its text analysis. Without this, a single
+ * image poisons the whole session: history is resent on every turn, so the
+ * provider rejects every subsequent request (HTTP 400).
+ *
+ * Config:
+ *   VERBOO_VISION_DELEGATE = auto (default) | off
+ *   VERBOO_VISION_MODEL    = pin a specific router model id
+ */
+
+/** Analysis text injected in place of an image block. */
+export function visionAnalysisMarker(model: string): string {
+  return `[Image analyzed by ${model}]`
+}
+
+export const IMAGE_REMOVED_PLACEHOLDER =
+  '[image removed: target model has no vision support]'
+
+export function isVisionDelegationEnabled(): boolean {
+  return (process.env.VERBOO_VISION_DELEGATE ?? 'auto').toLowerCase() !== 'off'
+}
+
+/**
+ * Whether a router model supports vision, using the catalog fetched from the
+ * Verboo router as the single source of truth.
+ *
+ * Returns:
+ *   `true`  — the model has `vision: true` in the router catalog.
+ *   `false` — the model has `vision: false` in the router catalog.
+ *   `undefined` — the model is not in the catalog or the catalog hasn't been
+ *                 fetched yet. The caller should NOT delegate in this state;
+ *                 the image stays inline (the catalog may arrive next turn).
+ */
+export function modelSupportsVision(modelId: string): boolean | undefined {
+  if (!modelId) return undefined
+
+  // Router ids may carry route prefixes ('pro/@preset/qwen3.6-27b') —
+  // try progressively stripped candidates.
+  const segments = modelId.split('/')
+  const candidates = [modelId]
+  if (segments.length > 1) {
+    candidates.push(segments.slice(1).join('/'))
+    candidates.push(segments[segments.length - 1] ?? '')
+  }
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    const meta = getVerbooModelMeta(candidate)
+    if (meta && typeof meta.vision === 'boolean') {
+      return meta.vision
+    }
+  }
+  return undefined
+}
+
+/**
+ * Pick the vision model to delegate to.
+ * Priority: VERBOO_VISION_MODEL env > vision-capable model from the cached
+ * router catalog > undefined (no model available).
+ *
+ * Returns `undefined` when no vision model is available, so the caller can
+ * degrade gracefully (images become a text placeholder).
+ */
+export function pickVisionModel(): string | undefined {
+  const pinned = process.env.VERBOO_VISION_MODEL
+  if (pinned) return pinned
+
+  const cached = getCachedVerbooModels()
+  if (cached) {
+    const vision = cached.find(m => m.vision === true)
+    if (vision) return vision.id
+  }
+  return undefined
+}
+
+// ---------------------------------------------------------------------------
+// Message scanning / rewriting
+// ---------------------------------------------------------------------------
+
+type Block = Record<string, unknown>
+type ShimMessage = {
+  role?: string
+  message?: { role?: string; content?: unknown }
+  content?: unknown
+  [key: string]: unknown
+}
+
+/** One vision call: the image blocks of a single user message or tool_result. */
+type ImageGroup = {
+  images: Block[]
+  context: string
+}
+
+export type VisionCaller = (args: {
+  model: string
+  images: Block[]
+  prompt: string
+}) => Promise<string>
+
+function getContent(msg: ShimMessage): unknown {
+  return msg.message?.content ?? msg.content
+}
+
+function isImageBlock(block: unknown): block is Block {
+  return (
+    !!block &&
+    typeof block === 'object' &&
+    (block as Block).type === 'image'
+  )
+}
+
+function imageHash(block: Block): string {
+  const source = block.source as
+    | { data?: string; url?: string }
+    | undefined
+  const payload = source?.data ?? source?.url ?? JSON.stringify(block)
+  return createHash('sha256').update(payload).digest('hex')
+}
+
+function groupKey(images: Block[]): string {
+  return images.map(imageHash).join('+')
+}
+
+export function messagesContainImages(messages: ShimMessage[]): boolean {
+  for (const msg of messages) {
+    const content = getContent(msg)
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (isImageBlock(block)) return true
+      if (
+        block?.type === 'tool_result' &&
+        Array.isArray(block.content) &&
+        block.content.some(isImageBlock)
+      ) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function extractText(content: unknown, limit = 500): string {
+  if (typeof content === 'string') return content.slice(0, limit)
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter(
+      (b): b is Block =>
+        !!b && typeof b === 'object' && (b as Block).type === 'text',
+    )
+    .map(b => String(b.text ?? ''))
+    .join('\n')
+    .slice(0, limit)
+}
+
+function buildDelegationPrompt(context: string): string {
+  return (
+    'You are the vision module of a coding assistant whose main model cannot ' +
+    'see images. Analyze the attached image(s) so the assistant can act on ' +
+    'your text alone. Transcribe ALL visible text verbatim (code, error ' +
+    'messages, labels, numbers). Describe layout, UI elements, colors and ' +
+    'anything relevant. Be precise and complete; do not speculate beyond ' +
+    'what is visible.' +
+    (context ? `\n\nContext for why the image was provided: ${context}` : '')
+  )
+}
+
+// Analysis cache. History is resent on every turn, so the same image would
+// otherwise trigger a fresh vision call each request.
+const analysisCache = new Map<string, string>()
+const inflightRequests = new Map<string, Promise<string>>()
+const ANALYSIS_CACHE_MAX = 50
+
+function cacheAnalysis(key: string, value: string): void {
+  if (analysisCache.size >= ANALYSIS_CACHE_MAX) {
+    const oldest = analysisCache.keys().next().value
+    if (oldest !== undefined) analysisCache.delete(oldest)
+  }
+  analysisCache.set(key, value)
+}
+
+/** Test hook. */
+export function clearVisionAnalysisCache(): void {
+  analysisCache.clear()
+  inflightRequests.clear()
+}
+
+async function analyzeGroup(
+  group: ImageGroup,
+  visionModel: string,
+  callVision: VisionCaller,
+): Promise<string> {
+  const key = groupKey(group.images)
+  const cached = analysisCache.get(key)
+  if (cached !== undefined) return cached
+
+  const pending = inflightRequests.get(key)
+  if (pending) return pending
+
+  const task = (async () => {
+    const analysis = await callVision({
+      model: visionModel,
+      images: group.images,
+      prompt: buildDelegationPrompt(group.context),
+    })
+    cacheAnalysis(key, analysis)
+    return analysis
+  })()
+  inflightRequests.set(key, task)
+  try {
+    return await task
+  } finally {
+    inflightRequests.delete(key)
+  }
+}
+
+/**
+ * Replace every image block in `messages` with the vision model's text
+ * analysis. Returns the original array untouched when there is nothing to do.
+ *
+ * When `visionModel` or `callVision` is undefined, image blocks become an
+ * explicit placeholder — the main request always proceeds image-free.
+ * A failed vision call degrades to a placeholder — it never throws.
+ */
+export async function delegateImagesInMessages(
+  messages: ShimMessage[],
+  visionModel?: string,
+  callVision?: VisionCaller,
+): Promise<ShimMessage[]> {
+  if (!messagesContainImages(messages)) return messages
+
+  // Map tool_use id -> tool name so tool_result images get a useful context.
+  const toolNameById = new Map<string, string>()
+  let lastUserText = ''
+  for (const msg of messages) {
+    const content = getContent(msg)
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (block?.type === 'tool_use' && block.id && block.name) {
+        toolNameById.set(String(block.id), String(block.name))
+      }
+    }
+  }
+
+  const analyzeAndFormat = async (group: ImageGroup): Promise<string> => {
+    if (!visionModel || !callVision) return IMAGE_REMOVED_PLACEHOLDER
+    try {
+      const analysis = await analyzeGroup(group, visionModel, callVision)
+      return `${visionAnalysisMarker(visionModel)}\n${analysis}`
+    } catch (error) {
+      logForDebugging(
+        `[VisionDelegate] vision call failed: ${(error as Error).message}`,
+        { level: 'warn' },
+      )
+      return `[Image could not be analyzed: ${(error as Error).message?.slice(0, 120) ?? 'unknown error'}]`
+    }
+  }
+
+  const rewriteBlocks = async (
+    blocks: unknown[],
+    context: string,
+  ): Promise<unknown[]> => {
+    const images = blocks.filter(isImageBlock)
+    if (images.length === 0) return blocks
+    if (!visionModel || !callVision) {
+      return blocks.map(block =>
+        isImageBlock(block)
+          ? { type: 'text', text: IMAGE_REMOVED_PLACEHOLDER }
+          : block,
+      )
+    }
+    const analysisText = await analyzeAndFormat({ images, context })
+    let first = true
+    return blocks.map(block => {
+      if (!isImageBlock(block)) return block
+      if (first) {
+        first = false
+        return { type: 'text', text: analysisText }
+      }
+      // Grouped images share one combined analysis (emitted above).
+      return { type: 'text', text: '[See combined image analysis above]' }
+    })
+  }
+
+  const result: ShimMessage[] = []
+  for (const msg of messages) {
+    const content = getContent(msg)
+    if (typeof content === 'string' || !Array.isArray(content)) {
+      if (msg.role === 'user' || msg.message?.role === 'user') {
+        const text = extractText(content)
+        if (text) lastUserText = text
+      }
+      result.push(msg)
+      continue
+    }
+
+    const isUser = msg.role === 'user' || msg.message?.role === 'user'
+    const userText = extractText(content)
+    if (isUser && userText) lastUserText = userText
+
+    let changed = false
+    const newContent: unknown[] = []
+    for (const block of content) {
+      if (isImageBlock(block)) {
+        // Handled at message level below (group all top-level images of this
+        // message into one call). Placeholder for position; replaced next.
+        newContent.push(block)
+        changed = true
+        continue
+      }
+      if (
+        block?.type === 'tool_result' &&
+        Array.isArray(block.content) &&
+        block.content.some(isImageBlock)
+      ) {
+        const toolName = toolNameById.get(String(block.tool_use_id ?? ''))
+        const context =
+          `image returned by tool ${toolName ?? 'unknown'}` +
+          (lastUserText ? `; user's request: ${lastUserText}` : '')
+        newContent.push({
+          ...block,
+          content: await rewriteBlocks(block.content, context),
+        })
+        changed = true
+        continue
+      }
+      newContent.push(block)
+    }
+
+    if (!changed) {
+      result.push(msg)
+      continue
+    }
+
+    // Rewrite the top-level image blocks (pasted images in user messages).
+    const context = isUser
+      ? userText
+        ? `the user sent the image with this message: ${userText}`
+        : 'image pasted by the user'
+      : lastUserText
+        ? `user's request: ${lastUserText}`
+        : ''
+    const finalContent = await rewriteBlocks(newContent, context)
+
+    if (msg.message) {
+      result.push({
+        ...msg,
+        message: { ...msg.message, content: finalContent },
+      })
+    } else {
+      result.push({ ...msg, content: finalContent })
+    }
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Belt and suspenders: strip anything that survived to the OpenAI wire format
+// ---------------------------------------------------------------------------
+
+type OpenAIPart = { type: string; text?: string; image_url?: unknown }
+
+/**
+ * Final safety pass over converted OpenAI-format messages. If any image_url
+ * part survived for a non-vision model, replace it with a text placeholder
+ * (and log — it means a path escaped the delegation pre-pass). Mutates
+ * nothing; returns a new array only when something was stripped.
+ */
+export function stripResidualImageParts(
+  openaiMessages: Array<Record<string, unknown>>,
+): { messages: Array<Record<string, unknown>>; removed: number } {
+  let removed = 0
+  const rewritten = openaiMessages.map(msg => {
+    const content = msg.content
+    if (!Array.isArray(content)) return msg
+    if (!content.some(p => (p as OpenAIPart)?.type === 'image_url')) return msg
+    removed += content.filter(
+      p => (p as OpenAIPart)?.type === 'image_url',
+    ).length
+    const parts = content.map(p =>
+      (p as OpenAIPart)?.type === 'image_url'
+        ? { type: 'text', text: IMAGE_REMOVED_PLACEHOLDER }
+        : p,
+    )
+    return { ...msg, content: parts }
+  })
+  if (removed > 0) {
+    logForDebugging(
+      `[VisionDelegate] stripped ${removed} residual image part(s) after conversion — a path escaped the pre-pass`,
+      { level: 'warn' },
+    )
+    return { messages: rewritten, removed }
+  }
+  return { messages: openaiMessages, removed: 0 }
+}

--- a/src/utils/imagePaste.test.ts
+++ b/src/utils/imagePaste.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'bun:test'
+import { getClipboardCommands, windowsPathToWsl } from './imagePaste.ts'
+
+// --- windowsPathToWsl -------------------------------------------------------
+
+test('converts backslash Windows paths to /mnt mounts', () => {
+  expect(windowsPathToWsl('C:\\Users\\jat\\Pictures\\shot.png')).toBe(
+    '/mnt/c/Users/jat/Pictures/shot.png',
+  )
+})
+
+test('converts forward-slash Windows paths to /mnt mounts', () => {
+  expect(windowsPathToWsl('D:/tmp/image.jpg')).toBe('/mnt/d/tmp/image.jpg')
+})
+
+test('lowercases the drive letter', () => {
+  expect(windowsPathToWsl('C:\\a.png')).toBe('/mnt/c/a.png')
+})
+
+test('leaves posix paths unchanged', () => {
+  expect(windowsPathToWsl('/home/user/image.png')).toBe(
+    '/home/user/image.png',
+  )
+})
+
+test('leaves relative paths unchanged', () => {
+  expect(windowsPathToWsl('image.png')).toBe('image.png')
+})
+
+// --- getClipboardCommands (wsl) ---------------------------------------------
+
+test('wsl clipboard commands go through powershell interop', () => {
+  const { commands } = getClipboardCommands('wsl')
+  expect(commands.checkImage).toContain('powershell')
+  expect(commands.checkImage).toContain('Get-Clipboard -Format Image')
+  expect(commands.saveImage).toContain('powershell')
+  // The PNG is written on the Windows side and copied across via wslpath
+  expect(commands.saveImage).toContain('wslpath -u')
+  expect(commands.getPath).toContain('Get-Clipboard')
+})
+
+test('wsl screenshot path stays on the Linux side for the reader', () => {
+  const { screenshotPath } = getClipboardCommands('wsl')
+  expect(screenshotPath.startsWith('/')).toBe(true)
+})
+
+test('linux clipboard commands are unchanged (xclip/wl-paste)', () => {
+  const { commands } = getClipboardCommands('linux')
+  expect(commands.checkImage).toContain('xclip')
+  expect(commands.saveImage).toContain('wl-paste')
+})

--- a/src/utils/imagePaste.ts
+++ b/src/utils/imagePaste.ts
@@ -18,6 +18,7 @@ import {
   maybeResizeAndDownsampleImageBuffer,
 } from './imageResizer.js'
 import { logError } from './log.js'
+import { getPlatform } from './platform.js'
 
 // Native NSPasteboard reader. GrowthBook gate tengu_collage_kaleidoscope is
 // a kill switch (default on). Falls through to osascript when off.
@@ -25,6 +26,38 @@ import { logError } from './log.js'
 // — module-scope helpers are NOT tree-shaken (see docs/feature-gating.md).
 
 type SupportedPlatform = 'darwin' | 'linux' | 'win32'
+// WSL is process.platform === 'linux' but the clipboard lives on the Windows
+// side, so it gets its own command set (powershell.exe interop).
+type EffectivePlatform = SupportedPlatform | 'wsl'
+
+/**
+ * PowerShell binary reachable from WSL. Prefer PATH (`powershell.exe` works
+ * when Windows interop is enabled), fall back to the canonical System32 path.
+ */
+export function getWslPowershellBin(): string {
+  const canonical =
+    '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
+  try {
+    if (getFsImplementation().existsSync(canonical)) {
+      return canonical
+    }
+  } catch {
+    // fall through to PATH lookup
+  }
+  return 'powershell.exe'
+}
+
+/**
+ * Convert a Windows path (C:\Users\... or C:/Users/...) to its WSL mount
+ * (/mnt/c/Users/...). Non-Windows paths are returned unchanged.
+ */
+export function windowsPathToWsl(path: string): string {
+  const match = path.match(/^([A-Za-z]):[\\/](.*)$/)
+  if (!match) {
+    return path
+  }
+  return `/mnt/${match[1].toLowerCase()}/${match[2].replace(/\\/g, '/')}`
+}
 
 // Threshold in characters for when to consider text a "large paste"
 export const PASTE_THRESHOLD = 800
@@ -53,8 +86,10 @@ export function buildLinuxClipboardSaveCommand(screenshotPath: string): string {
   ]).join(' || ')
 }
 
-function getClipboardCommands() {
-  const platform = process.platform as SupportedPlatform
+export function getClipboardCommands(platformOverride?: EffectivePlatform) {
+  const platform: EffectivePlatform =
+    platformOverride ??
+    (getPlatform() === 'wsl' ? 'wsl' : (process.platform as SupportedPlatform))
 
   // Platform-specific temporary file paths
   // Use CLAUDE_CODE_TMPDIR if set, otherwise fall back to platform defaults
@@ -62,17 +97,32 @@ function getClipboardCommands() {
     process.env.CLAUDE_CODE_TMPDIR ||
     (platform === 'win32' ? process.env.TEMP || 'C:\\Temp' : '/tmp')
   const screenshotFilename = 'claude_cli_latest_screenshot.png'
-  const tempPaths: Record<SupportedPlatform, string> = {
+  const tempPaths: Record<EffectivePlatform, string> = {
     darwin: join(baseTmpDir, screenshotFilename),
     linux: join(baseTmpDir, screenshotFilename),
     win32: join(baseTmpDir, screenshotFilename),
+    // WSL reads the final file from the Linux side; PowerShell writes to the
+    // Windows temp dir first and the save command copies it across.
+    wsl: join(baseTmpDir, screenshotFilename),
   }
 
   const screenshotPath = tempPaths[platform] || tempPaths.linux
 
+  // WSL: the clipboard lives on the Windows side. powershell.exe (default
+  // STA) can read it; the PNG is saved to %TEMP% and copied into the Linux
+  // filesystem via wslpath so the Node side reads the same screenshotPath
+  // as every other platform. Single PS spawn per step keeps paste latency
+  // comparable to the osascript path on macOS.
+  const wslPs = platform === 'wsl' ? getWslPowershellBin() : 'powershell.exe'
+  const wslSaveScript =
+    '$img = Get-Clipboard -Format Image; ' +
+    'if ($img) { $f = Join-Path $env:TEMP "claude_cli_latest_screenshot.png"; ' +
+    '$img.Save($f, [System.Drawing.Imaging.ImageFormat]::Png); Write-Output $f } ' +
+    'else { exit 1 }'
+
   // Platform-specific clipboard commands
   const commands: Record<
-    SupportedPlatform,
+    EffectivePlatform,
     {
       checkImage: string
       saveImage: string
@@ -99,6 +149,12 @@ function getClipboardCommands() {
       saveImage: `powershell -NoProfile -Command "$img = Get-Clipboard -Format Image; if ($img) { $img.Save('${screenshotPath.replace(/\\/g, '\\\\')}', [System.Drawing.Imaging.ImageFormat]::Png) }"`,
       getPath: 'powershell -NoProfile -Command "Get-Clipboard"',
       deleteFile: `del /f "${screenshotPath}"`,
+    },
+    wsl: {
+      checkImage: `${wslPs} -NoProfile -Command 'if ((Get-Clipboard -Format Image) -ne $null) { exit 0 } else { exit 1 }'`,
+      saveImage: `p="$(${wslPs} -NoProfile -Command '${wslSaveScript}' | tr -d '\\r')" && [ -n "$p" ] && cp "$(wslpath -u "$p")" "${screenshotPath}"`,
+      getPath: `${wslPs} -NoProfile -Command 'Get-Clipboard' | tr -d '\\r'`,
+      deleteFile: `rm -f "${screenshotPath}"`,
     },
   }
 
@@ -382,7 +438,16 @@ export async function tryReadImageFromPath(
     return null
   }
 
-  const imagePath = cleanedPath
+  // Under WSL, files dragged from Windows Explorer paste as C:\... paths,
+  // which Node on the Linux side cannot read — remap to /mnt/<drive>/...
+  // stripBackslashEscapes() would destroy C:\Users\... on WSL (it removes
+  // single backslashes), so use the raw trimmed text for the remap.
+  const isWsl = getPlatform() === 'wsl'
+  const rawPath = removeOuterQuotes(text.trim())
+  const imagePath =
+    isWsl && /^[A-Za-z]:[\\/]/.test(rawPath)
+      ? windowsPathToWsl(rawPath)
+      : cleanedPath
   let imageBuffer
 
   try {
@@ -392,7 +457,10 @@ export async function tryReadImageFromPath(
       // VSCode Terminal just grabs the text content which is the filename
       // instead of getting the full path of the file pasted with cmd-v. So
       // we check if it matches the filename of the image in the clipboard.
-      const clipboardPath = await getImagePathFromClipboard()
+      let clipboardPath = await getImagePathFromClipboard()
+      if (clipboardPath && isWsl) {
+        clipboardPath = windowsPathToWsl(clipboardPath)
+      }
       if (clipboardPath && imagePath === basename(clipboardPath)) {
         imageBuffer = getFsImplementation().readFileBytesSync(clipboardPath)
       }


### PR DESCRIPTION
## Summary

When the active model does not support vision (e.g. DeepSeek, Grok, Mistral), any image in the conversation history — pasted screenshots, FileRead of images, browser screenshots from MCP tools — causes every subsequent request to be rejected with HTTP 400 since the full history is resent each turn.

This PR adds a **pre-pass** that replaces image blocks with text analysis produced by a vision-capable router model before the main request is sent. No image ever reaches a blind model.

### Key changes

- **visionDelegate.ts**: core module with `modelSupportsVision()` (3-state: true/false/undefined from router catalog), `pickVisionModel()` (catalog-first, no hardcoded fallback), content-addressed image cache, graceful degradation to placeholder.
- **verbooModels.ts**: normalized `vision?: boolean` field from router catalog.
- **openaiShim.ts**: `_maybeDelegateVision()` + belt-and-suspenders `stripResidualImageParts()`.
- **WSL support**: clipboard image fallback via powershell.exe interop, windowsPathToWsl().

### Review feedback (from previous PR #6)

- modelSupportsVision uses router catalog only (3 states), no heuristics
- pickVisionModel prefers catalog over any fallback
- VerbooModel.vision normalized as suggested
- Delegation only exists in the Verboo client path
- When no vision model available, images become a text placeholder
- WSL: stripBackslashEscapes no longer destroys C:\ paths

Co-Authored-By: Verboo Code <noreply@code.verboo.ai>