### PR TITLE
fix: stabilize streaming during long-running agent tasks

### DIFF
--- a/src/__tests__/bugfixes-behavioral.test.ts
+++ b/src/__tests__/bugfixes-behavioral.test.ts
@@ -59,6 +59,7 @@ describe('watchdog.ts deterministic behavioral tests', () => {
   beforeEach(() => {
     logs = []
     state = createWatchdogState(100_000)
+    tickWaitingWatchdog(state, baseTasks, 0, mockLog, 100_000)
   })
 
   test('no heartbeat or stall when elapsed < WAITING_HEARTBEAT_MS', () => {
@@ -157,5 +158,41 @@ describe('watchdog.ts deterministic behavioral tests', () => {
     // Always returns purely informational action ('stall', 'heartbeat', 'none')
     // never returns a command to abort/kill or mutate task status.
     expect(['none', 'heartbeat', 'stall']).toContain(res.action)
+  })
+
+  test('first tick initializes lastProgressMs to prevent false stall when waiting_for_agents starts late', () => {
+    // Create state at time 100_000
+    const state = createWatchdogState(100_000)
+    logs = []
+
+    // First tick happens much later (100s after state creation)
+    // Without the fix, elapsed would be 100_000ms → false stall
+    // With the fix, lastProgressMs is set to nowMs on first tick
+    const result = tickWaitingWatchdog(
+      state,
+      baseTasks,
+      0,
+      mockLog,
+      200_000,
+    )
+
+    // Should NOT stall because first tick resets lastProgressMs
+    expect(result.action).not.toBe('stall')
+    expect(state.lastProgressMs).toBe(200_000)
+  })
+
+  test('empty task list initializes only once', () => {
+    const state = createWatchdogState(100_000)
+    tickWaitingWatchdog(state, [], 0, mockLog, 200_000)
+
+    const result = tickWaitingWatchdog(
+      state,
+      [],
+      0,
+      mockLog,
+      200_000 + WAITING_STALL_TIMEOUT_MS,
+    )
+
+    expect(result.action).toBe('stall')
   })
 })

--- a/src/__tests__/bugfixes-behavioral.test.ts
+++ b/src/__tests__/bugfixes-behavioral.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+import { createAssistantAPIErrorMessage, handleMessageFromStream } from '../utils/messages.ts'
+import {
+  createWatchdogState,
+  tickWaitingWatchdog,
+  WAITING_HEARTBEAT_MS,
+  WAITING_STALL_TIMEOUT_MS,
+  type WatchdogState,
+  type TaskProgressItem,
+} from '../utils/watchdog.ts'
+
+// ---------------------------------------------------------------------------
+// messages.ts: isApiErrorMessage resets stream mode (H3)
+// ---------------------------------------------------------------------------
+describe('messages.ts stream mode reset for API error messages', () => {
+  test('handleMessageFromStream calls onSetStreamMode for isApiErrorMessage', () => {
+    const msg = createAssistantAPIErrorMessage({
+      content: 'Test error',
+      error: 'unknown',
+    })
+
+    const streamModeCalls: string[] = []
+    const callbacks = {
+      onMessage: () => {},
+      onUpdateLength: () => {},
+      onSetStreamMode: (mode: string) => {
+        streamModeCalls.push(mode)
+      },
+      onStreamingToolUses: () => {},
+    }
+
+    handleMessageFromStream(
+      msg,
+      callbacks.onMessage,
+      callbacks.onUpdateLength,
+      callbacks.onSetStreamMode as (mode: string) => void,
+      callbacks.onStreamingToolUses as (f: unknown) => void,
+    )
+
+    expect(streamModeCalls).toContain('tool-use')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// watchdog.ts: Behavioral tests with deterministic clock
+// ---------------------------------------------------------------------------
+describe('watchdog.ts deterministic behavioral tests', () => {
+  let state: WatchdogState
+  let logs: Array<{ level: string; event: string; details: Record<string, unknown> }>
+
+  const mockLog = (level: 'info' | 'warn', event: string, details: Record<string, unknown>) => {
+    logs.push({ level, event, details })
+  }
+
+  const baseTasks: TaskProgressItem[] = [
+    { id: 'task-1', type: 'local_agent', outputOffset: 10 },
+  ]
+
+  beforeEach(() => {
+    logs = []
+    state = createWatchdogState(100_000)
+  })
+
+  test('no heartbeat or stall when elapsed < WAITING_HEARTBEAT_MS', () => {
+    const result = tickWaitingWatchdog(
+      state,
+      baseTasks,
+      0,
+      mockLog,
+      100_000 + WAITING_HEARTBEAT_MS - 1,
+    )
+    expect(result.action).toBe('none')
+    expect(logs).toHaveLength(0)
+  })
+
+  test('heartbeat fires when elapsed >= WAITING_HEARTBEAT_MS', () => {
+    const result = tickWaitingWatchdog(
+      state,
+      baseTasks,
+      0,
+      mockLog,
+      100_000 + WAITING_HEARTBEAT_MS,
+    )
+    expect(result.action).toBe('heartbeat')
+    expect(logs).toHaveLength(1)
+    expect(logs[0].level).toBe('info')
+    expect(logs[0].event).toBe('waiting_for_agents')
+  })
+
+  test('heartbeat rate-limited to once per WAITING_HEARTBEAT_MS', () => {
+    // First heartbeat at 30s
+    tickWaitingWatchdog(state, baseTasks, 0, mockLog, 100_000 + WAITING_HEARTBEAT_MS)
+    expect(logs).toHaveLength(1)
+
+    // Tick 100ms later -> no new log
+    tickWaitingWatchdog(state, baseTasks, 0, mockLog, 100_000 + WAITING_HEARTBEAT_MS + 100)
+    expect(logs).toHaveLength(1)
+
+    // Tick 5s later -> no new log
+    tickWaitingWatchdog(state, baseTasks, 0, mockLog, 100_000 + WAITING_HEARTBEAT_MS + 5_000)
+    expect(logs).toHaveLength(1)
+
+    // Tick after another 30s passes -> second heartbeat fires
+    tickWaitingWatchdog(state, baseTasks, 0, mockLog, 100_000 + 2 * WAITING_HEARTBEAT_MS)
+    expect(logs).toHaveLength(2)
+    expect(logs[1].event).toBe('waiting_for_agents')
+  })
+
+  test('stall warning fires once after WAITING_STALL_TIMEOUT_MS of inactivity', () => {
+    const stallTime = 100_000 + WAITING_STALL_TIMEOUT_MS
+    const res1 = tickWaitingWatchdog(state, baseTasks, 0, mockLog, stallTime)
+    expect(res1.action).toBe('stall')
+    expect(logs).toHaveLength(1)
+    expect(logs[0].level).toBe('warn')
+    expect(logs[0].event).toBe('waiting_for_agents_stalled')
+
+    // Subsequent ticks during continued stall do not re-emit warning
+    const res2 = tickWaitingWatchdog(state, baseTasks, 0, mockLog, stallTime + 5_000)
+    expect(res2.action).toBe('none')
+    expect(logs).toHaveLength(1)
+  })
+
+  test('progress in outputOffset resets stall state', () => {
+    const stallTime = 100_000 + WAITING_STALL_TIMEOUT_MS
+    tickWaitingWatchdog(state, baseTasks, 0, mockLog, stallTime)
+    expect(logs).toHaveLength(1)
+
+    // Output offset advances (e.g. agent produced log output)
+    const updatedTasks: TaskProgressItem[] = [
+      { id: 'task-1', type: 'local_agent', outputOffset: 250 },
+    ]
+    const progressTime = stallTime + 1_000
+    const res = tickWaitingWatchdog(state, updatedTasks, 0, mockLog, progressTime)
+
+    // Reset occurs, state.loggedStall is cleared
+    expect(state.loggedStall).toBe(false)
+    expect(state.lastProgressMs).toBe(progressTime)
+    expect(res.action).toBe('none')
+  })
+
+  test('progress in sdkEventCount resets stall state', () => {
+    const stallTime = 100_000 + WAITING_STALL_TIMEOUT_MS
+    tickWaitingWatchdog(state, baseTasks, 0, mockLog, stallTime)
+    expect(logs).toHaveLength(1)
+
+    // New SDK event arrives
+    const progressTime = stallTime + 500
+    tickWaitingWatchdog(state, baseTasks, 1, mockLog, progressTime)
+
+    expect(state.loggedStall).toBe(false)
+    expect(state.lastProgressMs).toBe(progressTime)
+  })
+
+  test('watchdog never alters task lifecycle or breaks execution loop', () => {
+    const stallTime = 100_000 + WAITING_STALL_TIMEOUT_MS * 2
+    const res = tickWaitingWatchdog(state, baseTasks, 0, mockLog, stallTime)
+    // Always returns purely informational action ('stall', 'heartbeat', 'none')
+    // never returns a command to abort/kill or mutate task status.
+    expect(['none', 'heartbeat', 'stall']).toContain(res.action)
+  })
+})

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -16,6 +16,11 @@ import {
 } from 'src/commands.js'
 import { createStreamlinedTransformer } from 'src/utils/streamlinedTransform.js'
 import { installStreamJsonStdoutGuard } from 'src/utils/streamJsonStdoutGuard.js'
+import {
+  createWatchdogState,
+  tickWaitingWatchdog,
+  type TaskProgressItem,
+} from 'src/utils/watchdog.js'
 import type { ToolPermissionContext } from 'src/Tool.js'
 import type { ThinkingConfig } from 'src/utils/thinking.js'
 import { assembleToolPool, filterToolsByDenyRules } from 'src/tools.js'
@@ -1920,6 +1925,8 @@ function runHeadlessStreaming(
     try {
       let command: QueuedCommand | undefined
       let waitingForAgents = false
+      let waitingSdkEventCount = 0
+      let watchdogState = createWatchdogState()
 
       // Extract command processing into a named function for the do-while pattern.
       // Drains the queue, batching consecutive prompt-mode commands into one
@@ -2366,6 +2373,7 @@ function runHeadlessStreaming(
         // Drain SDK events (task_started, task_progress) before command queue
         // so progress events precede task_notification on the stream.
         for (const event of drainSdkEvents()) {
+          waitingSdkEventCount++
           output.enqueue(event)
         }
 
@@ -2391,7 +2399,20 @@ function runHeadlessStreaming(
             waitingForAgents = true
             if (!hasMainThreadQueued) {
               runPhase = 'waiting_for_agents'
-              // No commands ready yet, wait for tasks to complete
+              const runningBgTasks = getRunningTasks(state)
+                .filter(t => isBackgroundTask(t) && t.type !== 'in_process_teammate')
+                .map((t): TaskProgressItem => ({
+                  id: t.id,
+                  type: t.type,
+                  outputOffset: t.outputOffset,
+                }))
+
+              tickWaitingWatchdog(
+                watchdogState,
+                runningBgTasks,
+                waitingSdkEventCount,
+                logForDiagnosticsNoPII,
+              )
               await sleep(100)
             }
             // Loop back to drain any newly queued commands

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6161,3 +6161,164 @@ test('emits reasoning_effort from codex alias default when no override is passed
 
   expect(requestBody?.reasoning_effort).toBe('high')
 })
+
+// ---------------------------------------------------------------------------
+// H1: thinking block close before premature stream close
+// ---------------------------------------------------------------------------
+test('yields content_block_stop(thinking) before premature-close error (H1)', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://example.test/v1'
+  process.env.OPENAI_API_KEY = 'test-key'
+  process.env.OPENAI_MODEL = 'deepseek-reasoner'
+  delete process.env.OPENAI_API_FORMAT
+
+  const encoder = new TextEncoder()
+  const lines: string[] = [
+    // message_start
+    `data: ${JSON.stringify({ id: 'msg1', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [], usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 } })}\n\n`,
+    // thinking block start
+    `data: ${JSON.stringify({ id: 'msg1', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [{ index: 0, delta: { reasoning_content: 'thinking...' }, finish_reason: null }] })}\n\n`,
+    // thinking delta
+    `data: ${JSON.stringify({ id: 'msg1', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [{ index: 0, delta: { reasoning_content: 'more thinking' }, finish_reason: null }] })}\n\n`,
+    // Stream closes WITHOUT finish_reason and WITHOUT [DONE]
+  ]
+
+  let readIndex = 0
+  globalThis.fetch = (async () => {
+    return new Response(
+      new ReadableStream({
+        pull(controller) {
+          if (readIndex < lines.length) {
+            controller.enqueue(encoder.encode(lines[readIndex++]))
+          } else {
+            controller.close()
+          }
+        },
+      }),
+      { headers: { 'Content-Type': 'text/event-stream' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const result = await client.beta.messages
+    .create({
+      model: 'deepseek-reasoner',
+      messages: [{ role: 'user', content: 'hi' }],
+      max_tokens: 16,
+      stream: true,
+    })
+    .withResponse()
+
+  const events: Array<Record<string, unknown>> = []
+  let thrown: unknown = null
+  try {
+    for await (const event of result.data) {
+      events.push(event)
+    }
+  } catch (e) {
+    thrown = e
+  }
+
+  // The generator must have thrown (premature close without finish_reason)
+  expect(thrown).toBeInstanceOf(Error)
+  expect((thrown as Error).message).toMatch(/without finish_reason/)
+
+  // Before the throw, the thinking block must have been closed
+  const thinkingStops = events.filter(
+    (e) => e.type === 'content_block_stop' && (e as { index?: unknown }).index === 0,
+  )
+  expect(thinkingStops.length).toBe(1)
+
+  // content_block_start(thinking) must have been emitted
+  const thinkingStarts = events.filter(
+    (e) =>
+      e.type === 'content_block_start' &&
+      (e as { content_block?: { type: string } })?.content_block?.type === 'thinking',
+  )
+  expect(thinkingStarts.length).toBe(1)
+
+  // No message_stop — premature close is a transport error, not a clean stop
+  const messageStops = events.filter((e) => e.type === 'message_stop')
+  expect(messageStops.length).toBe(0)
+})
+
+// ---------------------------------------------------------------------------
+// H3: thinking close + message_stop before in-stream APIError
+// ---------------------------------------------------------------------------
+test('yields content_block_stop(thinking) and idempotent message_stop before in-stream error (H3)', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'http://example.test/v1'
+  process.env.OPENAI_API_KEY = 'test-key'
+  process.env.OPENAI_MODEL = 'deepseek-reasoner'
+  delete process.env.OPENAI_API_FORMAT
+
+  const encoder = new TextEncoder()
+  const lines: string[] = [
+    // message_start
+    `data: ${JSON.stringify({ id: 'msg3', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [], usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 } })}\n\n`,
+    // thinking block delta
+    `data: ${JSON.stringify({ id: 'msg3', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [{ index: 0, delta: { reasoning_content: 'thinking deeply...' }, finish_reason: null }] })}\n\n`,
+    // In-stream error (gateway/proxy style)
+    `data: ${JSON.stringify({ error: { message: 'Upstream provider timeout', type: 'proxy_error', code: 'upstream_timeout' } })}\n\n`,
+  ]
+
+  let readIndex = 0
+  globalThis.fetch = (async () => {
+    return new Response(
+      new ReadableStream({
+        pull(controller) {
+          if (readIndex < lines.length) {
+            controller.enqueue(encoder.encode(lines[readIndex++]))
+          } else {
+            controller.close()
+          }
+        },
+      }),
+      { headers: { 'Content-Type': 'text/event-stream' } },
+    )
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const result = await client.beta.messages
+    .create({
+      model: 'deepseek-reasoner',
+      messages: [{ role: 'user', content: 'hi' }],
+      max_tokens: 16,
+      stream: true,
+    })
+    .withResponse()
+
+  const events: Array<Record<string, unknown>> = []
+  let thrown: unknown = null
+  try {
+    for await (const event of result.data) {
+      events.push(event)
+    }
+  } catch (e) {
+    thrown = e
+  }
+
+  // The generator MUST throw (in-stream error)
+  expect(thrown).toBeInstanceOf(Error)
+
+  // content_block_stop(thinking) must have been yielded before the error
+  const thinkingStops = events.filter(
+    (e) => e.type === 'content_block_stop' && (e as { index?: unknown }).index === 0,
+  )
+  expect(thinkingStops.length).toBe(1)
+
+  // message_stop must have been yielded before the error (at most once)
+  const messageStops = events.filter((e) => e.type === 'message_stop')
+  expect(messageStops.length).toBe(1)
+
+  // Order: content_block_stop → message_stop (both before the throw)
+  const cbsIdx = events.findIndex(
+    (e) => e.type === 'content_block_stop' && (e as { index?: unknown }).index === 0,
+  )
+  const msIdx = events.findIndex((e) => e.type === 'message_stop')
+  expect(cbsIdx).toBeGreaterThanOrEqual(0)
+  expect(msIdx).toBeGreaterThan(cbsIdx)
+
+  // message_stop must be the last yielded event
+  expect(msIdx).toBe(events.length - 1)
+})

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6165,7 +6165,26 @@ test('emits reasoning_effort from codex alias default when no override is passed
 // ---------------------------------------------------------------------------
 // H1: thinking block close before premature stream close
 // ---------------------------------------------------------------------------
-test('yields content_block_stop(thinking) before premature-close error (H1)', async () => {
+test.each([
+  ['thinking', { reasoning_content: 'thinking...' }],
+  ['text', { content: 'partial answer' }],
+  [
+    'tool_use',
+    {
+      tool_calls: [
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'Read', arguments: '{"file_path":' },
+        },
+      ],
+    },
+  ],
+])('closes %s block before premature-close error (H1)', async (
+  expectedBlockType,
+  delta,
+) => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'http://example.test/v1'
   process.env.OPENAI_API_KEY = 'test-key'
@@ -6176,10 +6195,8 @@ test('yields content_block_stop(thinking) before premature-close error (H1)', as
   const lines: string[] = [
     // message_start
     `data: ${JSON.stringify({ id: 'msg1', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [], usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 } })}\n\n`,
-    // thinking block start
-    `data: ${JSON.stringify({ id: 'msg1', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [{ index: 0, delta: { reasoning_content: 'thinking...' }, finish_reason: null }] })}\n\n`,
-    // thinking delta
-    `data: ${JSON.stringify({ id: 'msg1', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [{ index: 0, delta: { reasoning_content: 'more thinking' }, finish_reason: null }] })}\n\n`,
+    // active content block
+    `data: ${JSON.stringify({ id: 'msg1', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [{ index: 0, delta, finish_reason: null }] })}\n\n`,
     // Stream closes WITHOUT finish_reason and WITHOUT [DONE]
   ]
 
@@ -6223,29 +6240,46 @@ test('yields content_block_stop(thinking) before premature-close error (H1)', as
   expect(thrown).toBeInstanceOf(Error)
   expect((thrown as Error).message).toMatch(/without finish_reason/)
 
-  // Before the throw, the thinking block must have been closed
-  const thinkingStops = events.filter(
-    (e) => e.type === 'content_block_stop' && (e as { index?: unknown }).index === 0,
-  )
-  expect(thinkingStops.length).toBe(1)
-
-  // content_block_start(thinking) must have been emitted
-  const thinkingStarts = events.filter(
+  const blockStarts = events.filter(
     (e) =>
       e.type === 'content_block_start' &&
-      (e as { content_block?: { type: string } })?.content_block?.type === 'thinking',
+      (e as { content_block?: { type?: string } }).content_block?.type ===
+        expectedBlockType,
   )
-  expect(thinkingStarts.length).toBe(1)
+  expect(blockStarts).toHaveLength(1)
+
+  const blockStops = events.filter(
+    (e) => e.type === 'content_block_stop' && (e as { index?: unknown }).index === 0,
+  )
+  expect(blockStops).toHaveLength(1)
 
   // No message_stop — premature close is a transport error, not a clean stop
-  const messageStops = events.filter((e) => e.type === 'message_stop')
-  expect(messageStops.length).toBe(0)
+  expect(events.filter((e) => e.type === 'message_stop')).toHaveLength(0)
 })
 
 // ---------------------------------------------------------------------------
-// H3: thinking close + message_stop before in-stream APIError
+// H3: close active content without terminating an errored stream
 // ---------------------------------------------------------------------------
-test('yields content_block_stop(thinking) and idempotent message_stop before in-stream error (H3)', async () => {
+test.each([
+  ['thinking', { reasoning_content: 'thinking deeply...' }],
+  ['text', { content: 'partial answer' }],
+  [
+    'tool_use',
+    {
+      tool_calls: [
+        {
+          index: 0,
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'Read', arguments: '{"file_path":' },
+        },
+      ],
+    },
+  ],
+])('closes %s block without message_stop before in-stream error (H3)', async (
+  expectedBlockType,
+  delta,
+) => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'http://example.test/v1'
   process.env.OPENAI_API_KEY = 'test-key'
@@ -6256,8 +6290,8 @@ test('yields content_block_stop(thinking) and idempotent message_stop before in-
   const lines: string[] = [
     // message_start
     `data: ${JSON.stringify({ id: 'msg3', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [], usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 } })}\n\n`,
-    // thinking block delta
-    `data: ${JSON.stringify({ id: 'msg3', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [{ index: 0, delta: { reasoning_content: 'thinking deeply...' }, finish_reason: null }] })}\n\n`,
+    // active content block
+    `data: ${JSON.stringify({ id: 'msg3', object: 'chat.completion.chunk', model: 'deepseek-reasoner', choices: [{ index: 0, delta, finish_reason: null }] })}\n\n`,
     // In-stream error (gateway/proxy style)
     `data: ${JSON.stringify({ error: { message: 'Upstream provider timeout', type: 'proxy_error', code: 'upstream_timeout' } })}\n\n`,
   ]
@@ -6301,24 +6335,18 @@ test('yields content_block_stop(thinking) and idempotent message_stop before in-
   // The generator MUST throw (in-stream error)
   expect(thrown).toBeInstanceOf(Error)
 
-  // content_block_stop(thinking) must have been yielded before the error
-  const thinkingStops = events.filter(
+  const blockStarts = events.filter(
+    (e) =>
+      e.type === 'content_block_start' &&
+      (e as { content_block?: { type?: string } }).content_block?.type ===
+        expectedBlockType,
+  )
+  expect(blockStarts).toHaveLength(1)
+
+  const blockStops = events.filter(
     (e) => e.type === 'content_block_stop' && (e as { index?: unknown }).index === 0,
   )
-  expect(thinkingStops.length).toBe(1)
+  expect(blockStops).toHaveLength(1)
 
-  // message_stop must have been yielded before the error (at most once)
-  const messageStops = events.filter((e) => e.type === 'message_stop')
-  expect(messageStops.length).toBe(1)
-
-  // Order: content_block_stop → message_stop (both before the throw)
-  const cbsIdx = events.findIndex(
-    (e) => e.type === 'content_block_stop' && (e as { index?: unknown }).index === 0,
-  )
-  const msIdx = events.findIndex((e) => e.type === 'message_stop')
-  expect(cbsIdx).toBeGreaterThanOrEqual(0)
-  expect(msIdx).toBeGreaterThan(cbsIdx)
-
-  // message_stop must be the last yielded event
-  expect(msIdx).toBe(events.length - 1)
+  expect(events.filter((e) => e.type === 'message_stop')).toHaveLength(0)
 })

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1074,7 +1074,6 @@ async function* openaiStreamToAnthropic(
   let hasEmittedContentStart = false
   let hasEmittedThinkingStart = false
   let hasClosedThinking = false
-  let didEmitMessageStop = false
   const thinkFilter = createThinkTagFilter()
   let lastStopReason: 'tool_use' | 'max_tokens' | 'end_turn' | null = null
   let hasEmittedFinalUsage = false
@@ -1208,11 +1207,18 @@ async function* openaiStreamToAnthropic(
             }),
             { level: 'error' },
           )
-          // Close thinking block if open before throwing so consumers
+          // Close any active block before throwing so consumers
           // see a clean content event sequence (H1 fix).
+          if (hasEmittedContentStart) {
+            yield* closeActiveContentBlock()
+          }
           if (hasEmittedThinkingStart && !hasClosedThinking) {
             yield { type: 'content_block_stop', index: contentBlockIndex }
           }
+          for (const [, toolCall] of activeToolCalls) {
+            yield { type: 'content_block_stop', index: toolCall.index }
+          }
+          activeToolCalls.clear()
           throw new Error(
             `Upstream stream closed without finish_reason after ${elapsedSec}s — likely a guard_proxy/vLLM disconnect. The session was interrupted, not completed.`,
           )
@@ -1265,18 +1271,22 @@ async function* openaiStreamToAnthropic(
             typeof inStreamError.message === 'string'
               ? inStreamError.message
               : 'Provider returned an in-stream error'
-          // Close thinking block if open before error, so the TUI
-          // sees a clean content event sequence (H3 thinking fix).
+          // Close any open content block before error so consumers
+          // see a clean content event sequence (H3 fix).
+          if (hasEmittedContentStart) {
+            yield* closeActiveContentBlock()
+          }
           if (hasEmittedThinkingStart && !hasClosedThinking) {
             yield { type: 'content_block_stop', index: contentBlockIndex }
           }
-          // Yield an idempotent message_stop so downstream consumers
-          // reset stream state (e.g. TUI spinner) before the error
-          // propagates (H3 message_stop fix).
-          if (!didEmitMessageStop) {
-            didEmitMessageStop = true
-            yield { type: 'message_stop' }
+          for (const [, toolCall] of activeToolCalls) {
+            yield { type: 'content_block_stop', index: toolCall.index }
           }
+          activeToolCalls.clear()
+          // Do NOT yield message_stop here — the synthetic API error
+          // message (createAssistantAPIErrorMessage) is responsible for
+          // resetting the TUI spinner. Yielding message_stop before the
+          // throw would terminate the stream state prematurely.
           const errorPayload = {
             error: {
               message,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1074,6 +1074,7 @@ async function* openaiStreamToAnthropic(
   let hasEmittedContentStart = false
   let hasEmittedThinkingStart = false
   let hasClosedThinking = false
+  let didEmitMessageStop = false
   const thinkFilter = createThinkTagFilter()
   let lastStopReason: 'tool_use' | 'max_tokens' | 'end_turn' | null = null
   let hasEmittedFinalUsage = false
@@ -1207,6 +1208,11 @@ async function* openaiStreamToAnthropic(
             }),
             { level: 'error' },
           )
+          // Close thinking block if open before throwing so consumers
+          // see a clean content event sequence (H1 fix).
+          if (hasEmittedThinkingStart && !hasClosedThinking) {
+            yield { type: 'content_block_stop', index: contentBlockIndex }
+          }
           throw new Error(
             `Upstream stream closed without finish_reason after ${elapsedSec}s — likely a guard_proxy/vLLM disconnect. The session was interrupted, not completed.`,
           )
@@ -1259,6 +1265,18 @@ async function* openaiStreamToAnthropic(
             typeof inStreamError.message === 'string'
               ? inStreamError.message
               : 'Provider returned an in-stream error'
+          // Close thinking block if open before error, so the TUI
+          // sees a clean content event sequence (H3 thinking fix).
+          if (hasEmittedThinkingStart && !hasClosedThinking) {
+            yield { type: 'content_block_stop', index: contentBlockIndex }
+          }
+          // Yield an idempotent message_stop so downstream consumers
+          // reset stream state (e.g. TUI spinner) before the error
+          // propagates (H3 message_stop fix).
+          if (!didEmitMessageStop) {
+            didEmitMessageStop = true
+            yield { type: 'message_stop' }
+          }
           const errorPayload = {
             error: {
               message,

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -2997,6 +2997,12 @@ export function handleMessageFromStream(
           streamingEndedAt: Date.now(),
         }))
       }
+      // API error messages arrive as complete Message objects (not
+      // stream_event). Reset the TUI spinner so it doesn't stay in
+      // 'thinking' mode when the stream aborts mid-thinking (H3).
+      if (isSyntheticApiErrorMessage(message)) {
+        onSetStreamMode('tool-use')
+      }
     }
     // Clear streaming text NOW so the render can switch displayedMessages
     // from deferredMessages to messages in the same batch, making the

--- a/src/utils/watchdog.ts
+++ b/src/utils/watchdog.ts
@@ -5,6 +5,7 @@ export interface TaskProgressItem {
 }
 
 export interface WatchdogState {
+  initialized: boolean
   lastProgressMs: number
   lastHeartbeatLogMs: number
   loggedStall: boolean
@@ -17,6 +18,7 @@ export const WAITING_STALL_TIMEOUT_MS = 180_000
 
 export function createWatchdogState(nowMs: number = Date.now()): WatchdogState {
   return {
+    initialized: false,
     lastProgressMs: nowMs,
     lastHeartbeatLogMs: 0,
     loggedStall: false,
@@ -53,11 +55,17 @@ export function tickWaitingWatchdog(
 ): WatchdogTickResult {
   const currentSnapshot = computeTaskSnapshot(tasks)
 
-  const isInitialRun = state.prevTaskSnapshot === '' && state.prevSdkEventCount === 0
+  const isInitialRun = !state.initialized
 
   if (isInitialRun) {
+    state.initialized = true
     state.prevTaskSnapshot = currentSnapshot
     state.prevSdkEventCount = sdkEventCount
+    // Initialize lastProgressMs on first tick so elapsed time starts
+    // from when waiting_for_agents actually begins, not from when the
+    // state was created. Prevents false stall when waiting_for_agents
+    // starts late (H4 fix).
+    state.lastProgressMs = nowMs
   } else {
     const snapshotChanged = currentSnapshot !== state.prevTaskSnapshot
     const sdkEventsArrived = sdkEventCount !== state.prevSdkEventCount

--- a/src/utils/watchdog.ts
+++ b/src/utils/watchdog.ts
@@ -1,0 +1,102 @@
+export interface TaskProgressItem {
+  id?: string
+  type: string
+  outputOffset?: number
+}
+
+export interface WatchdogState {
+  lastProgressMs: number
+  lastHeartbeatLogMs: number
+  loggedStall: boolean
+  prevTaskSnapshot: string
+  prevSdkEventCount: number
+}
+
+export const WAITING_HEARTBEAT_MS = 30_000
+export const WAITING_STALL_TIMEOUT_MS = 180_000
+
+export function createWatchdogState(nowMs: number = Date.now()): WatchdogState {
+  return {
+    lastProgressMs: nowMs,
+    lastHeartbeatLogMs: 0,
+    loggedStall: false,
+    prevTaskSnapshot: '',
+    prevSdkEventCount: 0,
+  }
+}
+
+export function computeTaskSnapshot(tasks: TaskProgressItem[]): string {
+  return tasks
+    .map(t => `${t.id ?? t.type}:${t.outputOffset ?? 0}`)
+    .sort()
+    .join(',')
+}
+
+export interface WatchdogTickResult {
+  action: 'none' | 'heartbeat' | 'stall'
+  elapsedMs: number
+  taskSnapshot: string
+}
+
+export type LogDiagnosticsFn = (
+  level: 'info' | 'warn',
+  event: string,
+  details: Record<string, unknown>,
+) => void
+
+export function tickWaitingWatchdog(
+  state: WatchdogState,
+  tasks: TaskProgressItem[],
+  sdkEventCount: number,
+  logFn?: LogDiagnosticsFn,
+  nowMs: number = Date.now(),
+): WatchdogTickResult {
+  const currentSnapshot = computeTaskSnapshot(tasks)
+
+  const isInitialRun = state.prevTaskSnapshot === '' && state.prevSdkEventCount === 0
+
+  if (isInitialRun) {
+    state.prevTaskSnapshot = currentSnapshot
+    state.prevSdkEventCount = sdkEventCount
+  } else {
+    const snapshotChanged = currentSnapshot !== state.prevTaskSnapshot
+    const sdkEventsArrived = sdkEventCount !== state.prevSdkEventCount
+
+    if (snapshotChanged || sdkEventsArrived) {
+      state.prevTaskSnapshot = currentSnapshot
+      state.prevSdkEventCount = sdkEventCount
+      state.lastProgressMs = nowMs
+      state.loggedStall = false
+    }
+  }
+
+  const elapsedMs = nowMs - state.lastProgressMs
+
+  if (elapsedMs >= WAITING_STALL_TIMEOUT_MS) {
+    if (!state.loggedStall) {
+      state.loggedStall = true
+      logFn?.('warn', 'waiting_for_agents_stalled', {
+        timeout_ms: WAITING_STALL_TIMEOUT_MS,
+        elapsed_ms: elapsedMs,
+        task_snapshot: currentSnapshot,
+      })
+      return { action: 'stall', elapsedMs, taskSnapshot: currentSnapshot }
+    }
+    return { action: 'none', elapsedMs, taskSnapshot: currentSnapshot }
+  }
+
+  if (
+    state.lastProgressMs > 0 &&
+    elapsedMs >= WAITING_HEARTBEAT_MS &&
+    nowMs - state.lastHeartbeatLogMs >= WAITING_HEARTBEAT_MS
+  ) {
+    state.lastHeartbeatLogMs = nowMs
+    logFn?.('info', 'waiting_for_agents', {
+      elapsed_ms: elapsedMs,
+      task_snapshot: currentSnapshot,
+    })
+    return { action: 'heartbeat', elapsedMs, taskSnapshot: currentSnapshot }
+  }
+
+  return { action: 'none', elapsedMs, taskSnapshot: currentSnapshot }
+}


### PR DESCRIPTION
## Summary

- close active thinking, text, and tool-use blocks before propagating premature-close or in-stream provider errors
- leave errored streams without a terminal `message_stop`; the synthetic API error resets the TUI state
- initialize the diagnostic watchdog when `waiting_for_agents` actually starts
- keep the watchdog non-destructive: it records heartbeat and stall diagnostics without changing agent lifecycle

## Impact

- partial streamed content is finalized before an error reaches consumers
- errored streams are no longer presented as successfully completed
- the first waiting tick cannot report a false stall from time spent in the main turn
- agent execution and timeout behavior are unchanged

## Testing

- [x] `bun run smoke`
- [x] focused streaming/watchdog tests: 122 pass, 0 fail
- [x] thinking, text, and tool-use regressions cover premature-close and in-stream errors
- [x] `bun run security:pr-scan -- --base origin/main`
- [x] full `bun test --max-concurrency=1`: 2,534 pass and 123 unrelated baseline failures; upstream main is also red

## Notes

- provider/model path tested: Verboo OpenAI-compatible streaming with DeepSeek-style `reasoning_content` and gateway SSE errors
- screenshots: not applicable; no visual UI change
- GitHub Actions for this fork PR still require maintainer approval