### PR TITLE
feat(errors): 401 pós-upgrade mostra "plano sendo ativado" (não "faça login")

### DIFF
--- a/src/services/api/errors.planProvisioning.test.ts
+++ b/src/services/api/errors.planProvisioning.test.ts
@@ -1,0 +1,47 @@
+import { APIError } from '@anthropic-ai/sdk'
+import { expect, test } from 'bun:test'
+
+import { getAssistantMessageFromError } from './errors.js'
+
+function getFirstText(
+  message: ReturnType<typeof getAssistantMessageFromError>,
+): string {
+  const first = message.message.content[0]
+  if (!first || typeof first !== 'object' || !('text' in first)) {
+    return ''
+  }
+  return typeof first.text === 'string' ? first.text : ''
+}
+
+test('401 "Not Enough Credits" (provisionamento pós-upgrade) NÃO manda pro login', () => {
+  const error = APIError.generate(
+    401,
+    undefined,
+    'Not Enough Credits',
+    new Headers(),
+  )
+
+  const message = getAssistantMessageFromError(error, 'deepseek-v4-pro')
+  const text = getFirstText(message)
+
+  expect(message.isApiErrorMessage).toBe(true)
+  // mostra que o plano está sendo ativado...
+  expect(text.toLowerCase()).toContain('plan is being activated')
+  // ...e NÃO pede login (que não resolveria)
+  expect(text).not.toContain('/login')
+})
+
+test('401 de autenticação real CONTINUA orientando /login (sem regressão)', () => {
+  const error = APIError.generate(
+    401,
+    undefined,
+    'Invalid bearer token',
+    new Headers(),
+  )
+
+  const message = getAssistantMessageFromError(error, 'deepseek-v4-pro')
+  const text = getFirstText(message)
+
+  expect(message.isApiErrorMessage).toBe(true)
+  expect(text).toContain('/login')
+})

--- a/src/services/api/errors.planProvisioning.test.ts
+++ b/src/services/api/errors.planProvisioning.test.ts
@@ -1,7 +1,22 @@
 import { APIError } from '@anthropic-ai/sdk'
-import { expect, test } from 'bun:test'
+import { afterEach, expect, test } from 'bun:test'
 
-import { getAssistantMessageFromError } from './errors.js'
+import {
+  CREDIT_BALANCE_TOO_LOW_ERROR_MESSAGE,
+  getAssistantMessageFromError,
+  PLAN_ACCESS_PENDING_ERROR_MESSAGE,
+  PLAN_PROVISIONING_ERROR_MESSAGE,
+} from './errors.js'
+
+const originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL
+
+afterEach(() => {
+  if (originalAnthropicBaseUrl === undefined) {
+    delete process.env.ANTHROPIC_BASE_URL
+  } else {
+    process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl
+  }
+})
 
 function getFirstText(
   message: ReturnType<typeof getAssistantMessageFromError>,
@@ -13,11 +28,16 @@ function getFirstText(
   return typeof first.text === 'string' ? first.text : ''
 }
 
-test('401 "Not Enough Credits" (provisionamento pós-upgrade) NÃO manda pro login', () => {
+test('typed Verboo provisioning code reports plan activation', () => {
   const error = APIError.generate(
     401,
+    {
+      error: {
+        code: 'plan_provisioning',
+        message: 'Plan entitlement is still provisioning',
+      },
+    },
     undefined,
-    'Not Enough Credits',
     new Headers(),
   )
 
@@ -25,13 +45,62 @@ test('401 "Not Enough Credits" (provisionamento pós-upgrade) NÃO manda pro log
   const text = getFirstText(message)
 
   expect(message.isApiErrorMessage).toBe(true)
-  // mostra que o plano está sendo ativado...
-  expect(text.toLowerCase()).toContain('plan is being activated')
-  // ...e NÃO pede login (que não resolveria)
+  expect(message.error).toBe('billing_error')
+  expect(text).toBe(PLAN_PROVISIONING_ERROR_MESSAGE)
   expect(text).not.toContain('/login')
 })
 
-test('401 de autenticação real CONTINUA orientando /login (sem regressão)', () => {
+test('legacy exact Verboo credit message uses neutral pending copy', () => {
+  const error = APIError.generate(
+    401,
+    { error: 'Not Enough Credits' },
+    undefined,
+    new Headers(),
+  )
+
+  const message = getAssistantMessageFromError(error, 'deepseek-v4-pro')
+
+  expect(message.error).toBe('billing_error')
+  expect(getFirstText(message)).toBe(PLAN_ACCESS_PENDING_ERROR_MESSAGE)
+})
+
+test('external provider 401 is never described as Verboo provisioning', () => {
+  process.env.ANTHROPIC_BASE_URL = 'https://provider.example/v1'
+  const error = APIError.generate(
+    401,
+    { error: 'Not Enough Credits' },
+    undefined,
+    new Headers(),
+  )
+
+  const message = getAssistantMessageFromError(error, 'external-model')
+  const text = getFirstText(message)
+
+  expect(text).not.toContain(PLAN_PROVISIONING_ERROR_MESSAGE)
+  expect(text).not.toContain(PLAN_ACCESS_PENDING_ERROR_MESSAGE)
+  expect(message.error).toBe('authentication_failed')
+})
+
+test('typed exhausted credits stay a billing error without activation copy', () => {
+  const error = APIError.generate(
+    401,
+    {
+      error: {
+        code: 'insufficient_credits',
+        message: 'No credits remain',
+      },
+    },
+    undefined,
+    new Headers(),
+  )
+
+  const message = getAssistantMessageFromError(error, 'deepseek-v4-pro')
+
+  expect(message.error).toBe('billing_error')
+  expect(getFirstText(message)).toBe(CREDIT_BALANCE_TOO_LOW_ERROR_MESSAGE)
+})
+
+test('real authentication 401 still directs the user to login', () => {
   const error = APIError.generate(
     401,
     undefined,
@@ -43,5 +112,6 @@ test('401 de autenticação real CONTINUA orientando /login (sem regressão)', (
   const text = getFirstText(message)
 
   expect(message.isApiErrorMessage).toBe(true)
+  expect(message.error).toBe('authentication_failed')
   expect(text).toContain('/login')
 })

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -284,6 +284,8 @@ export function isMediaSizeErrorMessage(msg: AssistantMessage): boolean {
   )
 }
 export const CREDIT_BALANCE_TOO_LOW_ERROR_MESSAGE = 'Credit balance is too low'
+export const PLAN_PROVISIONING_ERROR_MESSAGE =
+  "Your plan is being activated. This can take a minute or two after an upgrade, so please wait a moment and try again. You don't need to log in."
 export const INVALID_API_KEY_ERROR_MESSAGE = 'Not logged in · Please run /login'
 export const INVALID_API_KEY_ERROR_MESSAGE_EXTERNAL =
   'Invalid API key · Fix external API key'
@@ -1018,6 +1020,25 @@ export function getAssistantMessageFromError(
     return createAssistantAPIErrorMessage({
       error: 'authentication_failed',
       content: getOauthOrgNotAllowedErrorMessage(),
+    })
+  }
+
+  // 401 de billing/provisionamento (ex.: logo após um upgrade de plano o
+  // entitlement ainda não propagou e o router responde "Not Enough Credits").
+  // Não é falha de autenticação: pedir /login não resolve e assusta o cliente
+  // no pior momento (recém pagou). Mostra que o plano está sendo ativado.
+  // Idealmente o router devolveria um código estável; enquanto isso, casamos
+  // pela mensagem retornada.
+  if (
+    error instanceof APIError &&
+    error.status === 401 &&
+    /not enough credits|insufficient credits|provision(ing|ed)/i.test(
+      error.message,
+    )
+  ) {
+    return createAssistantAPIErrorMessage({
+      content: PLAN_PROVISIONING_ERROR_MESSAGE,
+      error: 'billing_error',
     })
   }
 

--- a/src/services/api/errors.ts
+++ b/src/services/api/errors.ts
@@ -286,6 +286,8 @@ export function isMediaSizeErrorMessage(msg: AssistantMessage): boolean {
 export const CREDIT_BALANCE_TOO_LOW_ERROR_MESSAGE = 'Credit balance is too low'
 export const PLAN_PROVISIONING_ERROR_MESSAGE =
   "Your plan is being activated. This can take a minute or two after an upgrade, so please wait a moment and try again. You don't need to log in."
+export const PLAN_ACCESS_PENDING_ERROR_MESSAGE =
+  "We couldn't confirm access to your plan yet. If you upgraded recently, activation can take a minute or two. Please wait a moment and try again; if this continues, contact support."
 export const INVALID_API_KEY_ERROR_MESSAGE = 'Not logged in · Please run /login'
 export const INVALID_API_KEY_ERROR_MESSAGE_EXTERNAL =
   'Invalid API key · Fix external API key'
@@ -307,6 +309,46 @@ export function getCustomOffSwitchMessage(): string {
 export const CUSTOM_OFF_SWITCH_MESSAGE =
   'Opus is experiencing high load, please use /model to switch to Sonnet'
 export const API_TIMEOUT_ERROR_MESSAGE = 'Request timed out'
+
+function getAPIErrorBodyField(
+  error: APIError,
+  field: 'code' | 'error_code' | 'message',
+): string | undefined {
+  const body = error.error
+  if (!body || typeof body !== 'object') return undefined
+
+  const record = body as Record<string, unknown>
+  const nestedError = record.error
+  if (nestedError && typeof nestedError === 'object') {
+    const nestedValue = (nestedError as Record<string, unknown>)[field]
+    if (typeof nestedValue === 'string') return nestedValue
+  }
+
+  const value = record[field]
+  if (typeof value === 'string') return value
+  if (field === 'message' && typeof nestedError === 'string') {
+    return nestedError
+  }
+  return undefined
+}
+
+function getAPIErrorCode(error: APIError): string | undefined {
+  return (
+    getAPIErrorBodyField(error, 'code') ??
+    getAPIErrorBodyField(error, 'error_code')
+  )?.trim().toLowerCase()
+}
+
+function getAPIErrorDetail(error: APIError): string {
+  const bodyMessage = getAPIErrorBodyField(error, 'message')
+  if (bodyMessage) return bodyMessage.trim()
+  return error.message.replace(/^\d{3}\s+/, '').trim()
+}
+
+function isVerbooRouterError(): boolean {
+  return isVerbooMode() && isFirstPartyAnthropicBaseUrl()
+}
+
 export function getPdfTooLargeErrorMessage(): string {
   const limits = `max ${API_PDF_MAX_PAGES} pages, ${formatFileSize(PDF_TARGET_RAW_SIZE)}`
   return getIsNonInteractiveSession()
@@ -1023,23 +1065,43 @@ export function getAssistantMessageFromError(
     })
   }
 
-  // 401 de billing/provisionamento (ex.: logo após um upgrade de plano o
-  // entitlement ainda não propagou e o router responde "Not Enough Credits").
-  // Não é falha de autenticação: pedir /login não resolve e assusta o cliente
-  // no pior momento (recém pagou). Mostra que o plano está sendo ativado.
-  // Idealmente o router devolveria um código estável; enquanto isso, casamos
-  // pela mensagem retornada.
+  // Provisioning and billing codes are meaningful only for the Verboo router.
+  // Prefer the machine-readable code; legacy text is intentionally exact and
+  // receives neutral copy because it cannot prove that an upgrade happened.
   if (
     error instanceof APIError &&
     error.status === 401 &&
-    /not enough credits|insufficient credits|provision(ing|ed)/i.test(
-      error.message,
-    )
+    isVerbooRouterError()
   ) {
-    return createAssistantAPIErrorMessage({
-      content: PLAN_PROVISIONING_ERROR_MESSAGE,
-      error: 'billing_error',
-    })
+    const errorCode = getAPIErrorCode(error)
+    if (errorCode === 'plan_provisioning') {
+      return createAssistantAPIErrorMessage({
+        content: PLAN_PROVISIONING_ERROR_MESSAGE,
+        error: 'billing_error',
+      })
+    }
+
+    if (
+      errorCode === 'insufficient_credits' ||
+      errorCode === 'credit_balance_too_low' ||
+      errorCode === 'credits_exhausted'
+    ) {
+      return createAssistantAPIErrorMessage({
+        content: CREDIT_BALANCE_TOO_LOW_ERROR_MESSAGE,
+        error: 'billing_error',
+      })
+    }
+
+    const legacyDetail = getAPIErrorDetail(error).toLowerCase()
+    if (
+      legacyDetail === 'not enough credits' ||
+      legacyDetail === 'insufficient credits'
+    ) {
+      return createAssistantAPIErrorMessage({
+        content: PLAN_ACCESS_PENDING_ERROR_MESSAGE,
+        error: 'billing_error',
+      })
+    }
   }
 
   // Generic handler for other 401/403 authentication errors


### PR DESCRIPTION
## Problema

Um 401 de provisioning pós-upgrade não deve mandar o usuário para login, mas mensagens genéricas de crédito também não podem ser tratadas como prova de que houve upgrade.

## Implementação

- aceita o código estruturado plan_provisioning somente no router Verboo e mostra a mensagem afirmativa de ativação
- mantém compatibilidade com a mensagem legada exata usando texto neutro, sem afirmar que houve upgrade
- classifica códigos reais de crédito esgotado como billing_error, sem mensagem de ativação
- não aplica a regra a providers ou endpoints externos
- mantém o fluxo de login para erros reais de autenticação

## Contrato recomendado do backend

O router deve enviar error.code igual a plan_provisioning. Respostas legadas Not Enough Credits continuam suportadas de forma conservadora.

## Validação

- 5 testes específicos: código de provisioning, legado, provider externo, crédito esgotado e autenticação real
- 26 testes focados de erros e classificação passaram
- smoke/build passou