### PR TITLE
fix(skills): preserve per-turn model overrides

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -80,12 +80,8 @@ import {
 } from './utils/messageQueueManager.js'
 import { notifyCommandLifecycle } from './utils/commandLifecycle.js'
 import { headlessProfilerCheckpoint } from './utils/headlessProfiler.js'
-import {
-  getDefaultMainLoopModelSetting,
-  getRuntimeMainLoopModel,
-  parseUserSpecifiedModel,
-  renderModelName,
-} from './utils/model/model.js'
+import { renderModelName } from './utils/model/model.js'
+import { resolveQueryTurnModel } from './query/model.js'
 import {
   doesMostRecentAssistantMessageExceed200k,
   finalContextTokensFromLastResponse,
@@ -638,13 +634,12 @@ async function* queryLoop(
 
     const appState = toolUseContext.getAppState()
     const permissionMode = appState.toolPermissionContext.mode
-    const appStateMainLoopModel =
-      appState.mainLoopModelForSession ??
-      appState.mainLoopModel ??
-      getDefaultMainLoopModelSetting()
-    let currentModel = getRuntimeMainLoopModel({
+    const sessionModel =
+      appState.mainLoopModelForSession ?? appState.mainLoopModel
+    let currentModel = resolveQueryTurnModel({
       permissionMode,
-      mainLoopModel: parseUserSpecifiedModel(appStateMainLoopModel),
+      turnModel: toolUseContext.options.mainLoopModel,
+      sessionModel,
       exceeds200kTokens:
         permissionMode === 'plan' &&
         doesMostRecentAssistantMessageExceed200k(messagesForQuery),

--- a/src/query/model.test.ts
+++ b/src/query/model.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveQueryTurnModel } from './model.js'
+
+describe('resolveQueryTurnModel', () => {
+  test('prefers a skill model override to the persisted session model', () => {
+    expect(
+      resolveQueryTurnModel({
+        permissionMode: 'default',
+        turnModel: 'gpt-5.6-sol',
+        sessionModel: 'max/deepseek-v4-pro',
+      }),
+    ).toBe('gpt-5.6-sol')
+  })
+
+  test('supports same-provider worker model overrides', () => {
+    expect(
+      resolveQueryTurnModel({
+        permissionMode: 'default',
+        turnModel: 'max/mimo-v2.5-pro',
+        sessionModel: 'max/deepseek-v4-pro',
+      }),
+    ).toBe('max/mimo-v2.5-pro')
+  })
+
+  test('falls back to the persisted session model without a turn override', () => {
+    expect(
+      resolveQueryTurnModel({
+        permissionMode: 'default',
+        sessionModel: 'max/deepseek-v4-pro',
+      }),
+    ).toBe('max/deepseek-v4-pro')
+  })
+})

--- a/src/query/model.ts
+++ b/src/query/model.ts
@@ -1,0 +1,40 @@
+import type { PermissionMode } from '../utils/permissions/PermissionMode.js'
+import {
+  getDefaultMainLoopModelSetting,
+  getRuntimeMainLoopModel,
+  parseUserSpecifiedModel,
+} from '../utils/model/model.js'
+
+export type ResolveQueryTurnModelParams = {
+  permissionMode: PermissionMode
+  turnModel?: string
+  sessionModel?: string | null
+  exceeds200kTokens?: boolean
+}
+
+/**
+ * Resolve the model for one query turn.
+ *
+ * A slash command or skill can override the model for only that turn through
+ * ToolUseContext. The persisted session model is a fallback, not an override;
+ * otherwise SKILL.md `model:` is silently replaced immediately before the API
+ * call.
+ */
+export function resolveQueryTurnModel({
+  permissionMode,
+  turnModel,
+  sessionModel,
+  exceeds200kTokens = false,
+}: ResolveQueryTurnModelParams): string {
+  const requestedModel =
+    turnModel ??
+    parseUserSpecifiedModel(
+      sessionModel ?? getDefaultMainLoopModelSetting(),
+    )
+
+  return getRuntimeMainLoopModel({
+    permissionMode,
+    mainLoopModel: requestedModel,
+    exceeds200kTokens,
+  })
+}


### PR DESCRIPTION
## Summary

- preserve the per-turn model supplied through `ToolUseContext.options.mainLoopModel`
- use the persisted session model only when the current command or skill does not provide an override
- centralize the precedence rules in `resolveQueryTurnModel` and cover cross-provider, same-provider, and fallback behavior with focused tests

## Motivation and root cause

Skills can declare a model in `SKILL.md`, for example:

```yaml
model: gpt-5.6-sol
```

The skill loader correctly propagated that value into the turn's `ToolUseContext`. However, `queryLoop` recomputed `currentModel` from `appState.mainLoopModelForSession` / `appState.mainLoopModel` immediately before the API call. That silently discarded the skill override.

In practice, a session configured with `max/deepseek-v4-pro` continued sending `/plan` and worker skill requests to DeepSeek even when those skills explicitly selected another model. This made model-specialized planner, reviewer, and worker skills unreliable and affected both cross-provider and same-provider overrides.

The intended precedence is now explicit:

```text
turn/skill model -> persisted session model -> default model
```

Runtime transformations, including plan-mode context handling, are still applied after selecting the requested model.

## Impact

- user-facing impact: `SKILL.md` model declarations are respected for the API requests made by that skill; ordinary prompts without an override continue using the session model
- developer/maintainer impact: model precedence is isolated in a small testable helper instead of being duplicated inside the query loop

## Evidence

Manual runtime validation used the locally built CLI with the session model set to `max/deepseek-v4-pro`:

- inline skill with `model: gpt-5.6-sol` recorded `gpt-5.6-sol` in assistant transcript events
- forked skill with `model: gpt-5.6-sol` recorded `gpt-5.6-sol` in model usage
- same-provider worker skill with `model: max/mimo-v2.5-pro` recorded `max/mimo-v2.5-pro` in model usage
- ordinary follow-up prompts returned to `max/deepseek-v4-pro`, confirming the override remains turn-scoped

Before this change, the same scenarios resolved to the persisted `max/deepseek-v4-pro` session model.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun test src/query/model.test.ts` — 3 passed, 0 failed

## Notes

- provider/model path tested: Codex/OpenAI `gpt-5.6-sol`, plus Verboo `max/deepseek-v4-pro` and `max/mimo-v2.5-pro`
- screenshots attached: not applicable; this changes request routing rather than UI
- known limitation: the status line still displays the persisted session model while a turn-scoped skill override is active; transcripts and model usage report the actual request model
