### PR TITLE
chore(release): prepare v0.15.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verboo/code",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "description": "Verboo Code — coding agent for the Verboo platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release
- bump @verboo/code from 0.15.6 to 0.15.7
- include the restored original CLI mascot from PR 21

## Validation
- 149 release-critical tests passed
- bun run smoke reports 0.15.7
- npm pack --dry-run passed