### PR TITLE
chore(release): prepare v0.15.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verboo/code",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Verboo Code — coding agent for the Verboo platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release
- bump @verboo/code from 0.15.7 to 0.15.8
- ship the compact ghost UI redesign
- show the active Verboo, Codex, or Claude model dynamically

## Validation
- 149 release-critical tests passed
- 14 UI and active-model tests passed
- bun run smoke reports 0.15.8
- npm pack --dry-run passed