### PR TITLE
fix(release): install pinned Minisign binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,10 +296,22 @@ jobs:
           path: .artifacts/desktop-cli
           merge-multiple: true
 
-      - name: Install Minisign
+      - name: Install pinned Minisign
+        env:
+          MINISIGN_VERSION: "0.12"
+          MINISIGN_LINUX_SHA256: 9a599b48ba6eb7b1e80f12f36b94ceca7c00b7a5173c95c3efc88d9822957e73
         run: |
-          sudo apt-get update
-          sudo apt-get install -y minisign
+          ARCHIVE="$RUNNER_TEMP/minisign-linux.tar.gz"
+          BIN_DIR="$RUNNER_TEMP/minisign-bin"
+          curl --fail --location --retry 3 --silent --show-error \
+            "https://github.com/jedisct1/minisign/releases/download/${MINISIGN_VERSION}/minisign-${MINISIGN_VERSION}-linux.tar.gz" \
+            --output "$ARCHIVE"
+          printf '%s  %s\n' "$MINISIGN_LINUX_SHA256" "$ARCHIVE" | sha256sum --check --strict -
+          mkdir -p "$BIN_DIR"
+          tar -xzf "$ARCHIVE" -C "$BIN_DIR" --strip-components=2 minisign-linux/x86_64/minisign
+          chmod 0755 "$BIN_DIR/minisign"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
+          "$BIN_DIR/minisign" -v
 
       - name: Require protected signing configuration
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verboo/code",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "description": "Verboo Code — coding agent for the Verboo platform",
   "type": "module",
   "bin": {

--- a/scripts/desktop-release/contract.test.ts
+++ b/scripts/desktop-release/contract.test.ts
@@ -60,6 +60,11 @@ describe('desktop CLI release contract', () => {
     expect(releaseWorkflow).toContain("github.repository == 'verbeux-ai/code'")
     expect(releaseWorkflow).toContain('VERBOO_DESKTOP_MINISIGN_SECRET_KEY_B64')
     expect(releaseWorkflow).toContain('VERBOO_DESKTOP_MINISIGN_PUBLIC_KEY')
+    expect(releaseWorkflow).toContain('MINISIGN_VERSION: "0.12"')
+    expect(releaseWorkflow).toContain(
+      '9a599b48ba6eb7b1e80f12f36b94ceca7c00b7a5173c95c3efc88d9822957e73',
+    )
+    expect(releaseWorkflow).not.toContain('apt-get install -y minisign')
     expect(releaseWorkflow).toContain('gh release upload')
     expect(releaseWorkflow).not.toContain('--clobber')
     expect(pullRequestWorkflow).not.toContain('gh release upload')


### PR DESCRIPTION
## Summary
- replace unavailable Ubuntu apt package with the official Minisign 0.12 Linux binary
- verify its pinned SHA-256 before execution
- add a contract regression assertion
- bump @verboo/code to 0.15.10 because 0.15.9 is already published

## Validation
- bun run desktop:test
- verified the pinned archive hash and exact Linux binary extraction
- bun run smoke
- npm pack --dry-run