### PR TITLE
fix(tools): recover provider-truncated tool names

### DIFF
--- a/src/Tool.test.ts
+++ b/src/Tool.test.ts
@@ -13,11 +13,20 @@ describe('findToolByNameOrUniquePrefix', () => {
     expect(findToolByNameOrUniquePrefix(tools, 'Rea')?.name).toBe('Read')
   })
 
-  test('does not guess short, ambiguous, or MCP tool names', () => {
+  test('prefers a unique one-character completion over longer deferred tools', () => {
+    expect(
+      findToolByNameOrUniquePrefix(
+        [{ name: 'Read' }, { name: 'ReadMcpResourceTool' }] as Tools,
+        'Rea',
+      )?.name,
+    ).toBe('Read')
+  })
+
+  test('does not guess short, genuinely ambiguous, or MCP tool names', () => {
     expect(findToolByNameOrUniquePrefix(tools, 'R')).toBeUndefined()
     expect(
       findToolByNameOrUniquePrefix(
-        [{ name: 'Read' }, { name: 'Ready' }] as Tools,
+        [{ name: 'Read' }, { name: 'Real' }] as Tools,
         'Rea',
       ),
     ).toBeUndefined()

--- a/src/Tool.test.ts
+++ b/src/Tool.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+
+import { findToolByNameOrUniquePrefix, type Tools } from './Tool.js'
+
+const tools = [
+  { name: 'Read' },
+  { name: 'Bash' },
+  { name: 'Grep' },
+] as Tools
+
+describe('findToolByNameOrUniquePrefix', () => {
+  test('recovers an unambiguous provider-truncated built-in tool name', () => {
+    expect(findToolByNameOrUniquePrefix(tools, 'Rea')?.name).toBe('Read')
+  })
+
+  test('does not guess short, ambiguous, or MCP tool names', () => {
+    expect(findToolByNameOrUniquePrefix(tools, 'R')).toBeUndefined()
+    expect(
+      findToolByNameOrUniquePrefix(
+        [{ name: 'Read' }, { name: 'Ready' }] as Tools,
+        'Rea',
+      ),
+    ).toBeUndefined()
+    expect(
+      findToolByNameOrUniquePrefix(
+        [{ name: 'mcp__files__read' }] as Tools,
+        'mcp__files__rea',
+      ),
+    ).toBeUndefined()
+  })
+})

--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -374,6 +374,25 @@ export function findToolByName(tools: Tools, name: string): Tool | undefined {
   return tools.find(t => toolMatchesName(t, name))
 }
 
+/**
+ * Resolves a provider-truncated built-in tool name only when the prefix is
+ * unambiguous among tools already available to the model. This keeps malformed
+ * calls such as `Rea` recoverable as `Read` without guessing MCP tool names or
+ * accepting very short, collision-prone prefixes.
+ */
+export function findToolByNameOrUniquePrefix(
+  tools: Tools,
+  name: string,
+): Tool | undefined {
+  const exactMatch = findToolByName(tools, name)
+  if (exactMatch) return exactMatch
+
+  if (name.length < 3 || name.startsWith('mcp__')) return undefined
+
+  const prefixMatches = tools.filter(tool => tool.name.startsWith(name))
+  return prefixMatches.length === 1 ? prefixMatches[0] : undefined
+}
+
 export type Tool<
   Input extends AnyObject = AnyObject,
   Output = unknown,

--- a/src/Tool.ts
+++ b/src/Tool.ts
@@ -376,9 +376,10 @@ export function findToolByName(tools: Tools, name: string): Tool | undefined {
 
 /**
  * Resolves a provider-truncated built-in tool name only when the prefix is
- * unambiguous among tools already available to the model. This keeps malformed
- * calls such as `Rea` recoverable as `Read` without guessing MCP tool names or
- * accepting very short, collision-prone prefixes.
+ * unambiguous. Prefer a unique one-character completion before considering
+ * longer names: `Rea` should recover `Read` even when the deferred
+ * `ReadMcpResourceTool` is also registered. Do not guess MCP names or accept
+ * very short, collision-prone prefixes.
  */
 export function findToolByNameOrUniquePrefix(
   tools: Tools,
@@ -390,6 +391,13 @@ export function findToolByNameOrUniquePrefix(
   if (name.length < 3 || name.startsWith('mcp__')) return undefined
 
   const prefixMatches = tools.filter(tool => tool.name.startsWith(name))
+  const oneCharacterCompletions = prefixMatches.filter(
+    tool => tool.name.length === name.length + 1,
+  )
+  if (oneCharacterCompletions.length === 1) {
+    return oneCharacterCompletions[0]
+  }
+
   return prefixMatches.length === 1 ? prefixMatches[0] : undefined
 }
 

--- a/src/services/tools/StreamingToolExecutor.ts
+++ b/src/services/tools/StreamingToolExecutor.ts
@@ -5,7 +5,11 @@ import {
   withMemoryCorrectionHint,
 } from 'src/utils/messages.js'
 import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
-import { findToolByName, type Tools, type ToolUseContext } from '../../Tool.js'
+import {
+  findToolByNameOrUniquePrefix,
+  type Tools,
+  type ToolUseContext,
+} from '../../Tool.js'
 import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
 import type { AssistantMessage, Message } from '../../types/message.js'
 import { createChildAbortController } from '../../utils/abortController.js'
@@ -80,7 +84,10 @@ export class StreamingToolExecutor {
    * Add a tool to the execution queue. Will start executing immediately if conditions allow.
    */
   addTool(block: ToolUseBlock, assistantMessage: AssistantMessage): void {
-    const toolDefinition = findToolByName(this.toolDefinitions, block.name)
+    const toolDefinition = findToolByNameOrUniquePrefix(
+      this.toolDefinitions,
+      block.name,
+    )
     if (!toolDefinition) {
       this.tools.push({
         id: block.id,

--- a/src/services/tools/StreamingToolExecutor.ts
+++ b/src/services/tools/StreamingToolExecutor.ts
@@ -10,6 +10,7 @@ import {
   type Tools,
   type ToolUseContext,
 } from '../../Tool.js'
+import { getAllBaseTools } from '../../tools.js'
 import { BASH_TOOL_NAME } from '../../tools/BashTool/toolName.js'
 import type { AssistantMessage, Message } from '../../types/message.js'
 import { createChildAbortController } from '../../utils/abortController.js'
@@ -84,10 +85,22 @@ export class StreamingToolExecutor {
    * Add a tool to the execution queue. Will start executing immediately if conditions allow.
    */
   addTool(block: ToolUseBlock, assistantMessage: AssistantMessage): void {
-    const toolDefinition = findToolByNameOrUniquePrefix(
+    let toolDefinition = findToolByNameOrUniquePrefix(
       this.toolDefinitions,
       block.name,
     )
+    if (!toolDefinition) {
+      const baseTool = findToolByNameOrUniquePrefix(
+        getAllBaseTools(),
+        block.name,
+      )
+      if (baseTool && !baseTool.isMcp && baseTool.name !== block.name) {
+        toolDefinition = baseTool
+        logForDebugging(
+          `Recovered truncated base tool name ${block.name} as ${baseTool.name}: ${block.id}`,
+        )
+      }
+    }
     if (!toolDefinition) {
       this.tools.push({
         id: block.id,

--- a/src/services/tools/StreamingToolExecutor.ts
+++ b/src/services/tools/StreamingToolExecutor.ts
@@ -6,6 +6,7 @@ import {
 } from 'src/utils/messages.js'
 import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
 import {
+  findToolByName,
   findToolByNameOrUniquePrefix,
   type Tools,
   type ToolUseContext,

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -29,6 +29,7 @@ import {
 import type { CanUseToolFn } from '../../hooks/useCanUseTool.js'
 import {
   findToolByName,
+  findToolByNameOrUniquePrefix,
   type Tool,
   type ToolProgress,
   type ToolProgressData,
@@ -388,7 +389,16 @@ export async function* runToolUse(
 ): AsyncGenerator<MessageUpdateLazy, void> {
   const toolName = toolUse.name
   // First try to find in the available tools (what the model sees)
-  let tool = findToolByName(toolUseContext.options.tools, toolName)
+  let tool = findToolByNameOrUniquePrefix(
+    toolUseContext.options.tools,
+    toolName,
+  )
+
+  if (tool && tool.name !== toolName) {
+    logForDebugging(
+      `Recovered truncated tool name ${toolName} as ${tool.name}: ${toolUse.id}`,
+    )
+  }
 
   // If not found, check if it's a deprecated tool being called by alias
   // (e.g., old transcripts calling "KillShell" which is now an alias for "TaskStop")

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -404,10 +404,24 @@ export async function* runToolUse(
   // (e.g., old transcripts calling "KillShell" which is now an alias for "TaskStop")
   // Only fall back for tools where the name matches an alias, not the primary name
   if (!tool) {
-    const fallbackTool = findToolByName(getAllBaseTools(), toolName)
-    // Only use fallback if the tool was found via alias (deprecated name)
-    if (fallbackTool && fallbackTool.aliases?.includes(toolName)) {
+    const fallbackTool = findToolByNameOrUniquePrefix(
+      getAllBaseTools(),
+      toolName,
+    )
+    // A model can only call a tool it received in its schema. Recover an exact
+    // alias or an unambiguous truncated built-in name when filtering removed
+    // the original definition from this execution path.
+    if (
+      fallbackTool &&
+      (fallbackTool.aliases?.includes(toolName) ||
+        (!fallbackTool.isMcp && fallbackTool.name !== toolName))
+    ) {
       tool = fallbackTool
+      if (tool.name !== toolName) {
+        logForDebugging(
+          `Recovered truncated base tool name ${toolName} as ${tool.name}: ${toolUse.id}`,
+        )
+      }
     }
   }
   const messageId = assistantMessage.message.id


### PR DESCRIPTION
## Summary

Some providers emit tool calls with **truncated tool names** (e.g. `Read` → `Rea`, `EnterPlanMode` → `EnterPlanMo`). The executor failed those with `No such tool available: <name>`, forcing the model to retry or give up on tools like `Read`/`EnterPlanMode`.

- **`findToolByNameOrUniquePrefix`** (`Tool.ts`): when an exact name lookup fails, recover via prefix matching — only when the prefix is unambiguous, never for MCP tool names, and only for names ≥ 3 chars.
- **Unique one-character completion**: `Rea` recovers as `Read` even when the deferred `ReadMcpResourceTool` is also registered (a longer prefix match).
- **Fallback after permission filtering** (`StreamingToolExecutor`): recover truncated names against base tools when the definition was filtered out of the model's available set.
- **Same recovery in `runToolUse`** (`toolExecution.ts`) for the direct-execution path.

Also includes `fix(tools): restore findToolByName import for interrupt handling` — 7523ea3 swapped the import but `getToolInterruptBehavior` still calls `findToolByName`, which would throw a `ReferenceError` on the cancel/interrupt path.

## Test plan

- `bun test ./src/Tool.test.ts` — 3 pass (new recovery cases)
- `bun test ./src/services/tools/` — 12 pass across 4 files (Tool, StreamingToolExecutor tool pairing, toolExecution, tool result pairing)

## Notes

- Deliberately does **not** guess MCP tool names or accept prefixes < 3 chars / ambiguous prefixes.
- Trade-off: a unique one-character completion can pick a shorter tool when the model meant a longer one; bounded and documented in code.