### PR TITLE
chore(release): prepare v0.15.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verboo/code",
-  "version": "0.15.14",
+  "version": "0.15.15",
   "description": "Verboo Code — coding agent for the Verboo platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump the CLI package version from 0.15.14 to 0.15.15
- prepare the startup feedback campaign feature for publication

## Testing

- [x] bun run desktop:test
- [x] bun run build
- [x] node dist/cli.mjs --version

## Release safety

- [x] release environment contains both required Minisign secret names
- [x] signed desktop CLI publication job is enabled
- [x] version commit changes only package.json