### PR TITLE
chore(release): prepare v0.15.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verboo/code",
-  "version": "0.15.15",
+  "version": "0.15.16",
   "description": "Verboo Code — coding agent for the Verboo platform",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- bump `@verboo/code` from 0.15.15 to 0.15.16
- prepare the patch release containing the fragmented tool-name recovery merged in #40

## Impact

- user-facing impact: makes the tool-name streaming fix available through the normal npm, Docker, and signed desktop CLI release channels
- developer/maintainer impact: aligns `package.json` with the intended `v0.15.16` release tag

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] focused tests: inherited from #40 (174 passing)
- [x] desktop release tests: inherited from #40 (17 passing locally and four native CI jobs)

## Notes

- provider/model path tested: see #40
- screenshots attached (if UI changed): not applicable
- follow-up work or known limitations: none
