### PR TITLE
fix(chrome): sync managed MCP tool catalog 1.4.0

### DIFF
--- a/src/skills/bundled/verbooInChrome.test.ts
+++ b/src/skills/bundled/verbooInChrome.test.ts
@@ -17,6 +17,8 @@ test('Verboo in Chrome skill exposes the real MCP tool contract', async () => {
   expect(skill?.allowedTools).toEqual([
     'mcp__verboo-in-chrome__navigate',
     'mcp__verboo-in-chrome__read_page',
+    'mcp__verboo-in-chrome__find',
+    'mcp__verboo-in-chrome__extract_page_content',
     'mcp__verboo-in-chrome__structured_extract',
     'mcp__verboo-in-chrome__click',
     'mcp__verboo-in-chrome__type',

--- a/src/utils/verbooInChrome.test.ts
+++ b/src/utils/verbooInChrome.test.ts
@@ -111,6 +111,8 @@ test('browser guidance matches the tools exposed by the Verboo extension', () =>
   for (const tool of [
     'navigate',
     'read_page',
+    'find',
+    'extract_page_content',
     'structured_extract',
     'click',
     'type',

--- a/src/utils/verbooInChrome.ts
+++ b/src/utils/verbooInChrome.ts
@@ -7,6 +7,8 @@ export const VERBOO_IN_CHROME_MANAGED_MARKER = 'VERBOO_IN_CHROME_MANAGED'
 export const VERBOO_IN_CHROME_TOOL_NAMES = [
   'navigate',
   'read_page',
+  'find',
+  'extract_page_content',
   'structured_extract',
   'click',
   'type',


### PR DESCRIPTION
## Why

The managed Verboo in Chrome MCP (extension 0.4.0 / tool catalog 1.4.0) now exposes 10 tools, but the CLI still advertised and authorized only the previous 8. The two new controller tools were invisible to the managed-MCP allowlist, so the CLI could not grant or announce them.

## What

Adds `find` and `extract_page_content` to `VERBOO_IN_CHROME_TOOL_NAMES` in canonical catalog order, and updates the two contract tests that pin the tool list:

- `src/utils/verbooInChrome.ts` — canonical tool-name array
- `src/utils/verbooInChrome.test.ts` — browser-guidance contract
- `src/skills/bundled/verbooInChrome.test.ts` — bundled-skill `allowedTools` contract

## Scope

No extension code, no Rust, no UI, no docs, no legacy `claudeInChrome` paths. Exactly three files, +6 lines, no deletions.

## Tests

- Focused suites: `bun test src/utils/verbooInChrome.test.ts src/skills/bundled/verbooInChrome.test.ts` → 7 pass / 0 fail.
- `bun run build` → exit 0 (external lists valid, SDK declarations in sync).
- CLI smoke: `node dist/cli.mjs --version` → `0.15.16`, exit 0.

## Baseline transparency

Measured on a clean checkout at the base commit versus this patch: `typecheck` reports the same 1703 signatures, the full suite shows the same 2723 pass / 138 fail, and `rebrand:check` shows the same 35 complaints — zero delta of failures introduced by this change; the pre-existing failures are unrelated to this surface.

## Compatibility

Older helpers may not offer the two new tools. The resulting error is visible and recoverable (unknown tool is reported by the MCP layer instead of failing silently). Version-gating the tool list per helper version is intentionally left out of this minimal patch.
